### PR TITLE
Changed colors for disabled buttons with outlined form

### DIFF
--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -31,6 +31,8 @@ export const lightColors = {
   hoverRed: "#FCF2F4",
   lightRed: "#C83B51",
   divisorColor: "#E3E3E3",
+  disabledBGGrey: "#D5D7D7",
+  disabledInnerGrey: "#B4B4B4",
 };
 
 export const darkColors = {
@@ -50,6 +52,8 @@ export const darkColors = {
   mainRed: "#FF3958",
   hoverRed: "#4B586A",
   divisorColor: "#E3E3E3",
+  disabledBGGrey: "#616A7C",
+  disabledInnerGrey: "#3A3F4A",
 };
 
 export const lightTheme = {
@@ -67,10 +71,10 @@ export const lightTheme = {
         iconColor: lightColors.mainGrey,
       },
       disabled: {
-        border: lightColors.disabledGrey,
-        text: lightColors.pressedGrey,
-        background: lightColors.white,
-        iconColor: lightColors.mainGrey,
+        border: lightColors.disabledInnerGrey,
+        text: lightColors.disabledInnerGrey,
+        background: lightColors.disabledBGGrey,
+        iconColor: lightColors.disabledInnerGrey,
       },
       hover: {
         border: lightColors.mainGrey,
@@ -119,10 +123,10 @@ export const lightTheme = {
         iconColor: lightColors.mainRed,
       },
       disabled: {
-        border: lightColors.disabledGrey,
-        text: lightColors.mainGrey,
-        background: lightColors.white,
-        iconColor: lightColors.mainGrey,
+        border: lightColors.disabledInnerGrey,
+        text: lightColors.disabledInnerGrey,
+        background: lightColors.disabledBGGrey,
+        iconColor: lightColors.disabledInnerGrey,
       },
       hover: {
         border: lightColors.lightRed,
@@ -155,10 +159,10 @@ export const darkTheme = {
         iconColor: darkColors.mainGrey,
       },
       disabled: {
-        border: darkColors.disabledGrey,
-        text: darkColors.mainGrey,
-        background: darkColors.dark,
-        iconColor: darkColors.mainGrey,
+        border: darkColors.disabledInnerGrey,
+        text: darkColors.disabledInnerGrey,
+        background: darkColors.disabledBGGrey,
+        iconColor: darkColors.disabledInnerGrey,
       },
       hover: {
         border: darkColors.mainGrey,
@@ -207,10 +211,10 @@ export const darkTheme = {
         iconColor: darkColors.mainRed,
       },
       disabled: {
-        border: darkColors.disabledGrey,
-        text: darkColors.mainGrey,
-        background: darkColors.dark,
-        iconColor: darkColors.mainGrey,
+        border: darkColors.disabledInnerGrey,
+        text: darkColors.disabledInnerGrey,
+        background: darkColors.disabledBGGrey,
+        iconColor: darkColors.disabledInnerGrey,
       },
       hover: {
         border: darkColors.mainRed,


### PR DESCRIPTION
## What does this do?

Changed colors for disabled buttons with outlined form

## How does it look?

<img width="825" alt="Screenshot 2022-10-31 at 15 51 00" src="https://user-images.githubusercontent.com/33497058/199117967-012dc93e-da0b-4d5e-b085-3a6eb9c1848d.png">
<img width="817" alt="Screenshot 2022-10-31 at 15 50 55" src="https://user-images.githubusercontent.com/33497058/199117969-068ec56a-b0d2-4a1a-b683-a7731589d317.png">
<img width="746" alt="Screenshot 2022-10-31 at 15 50 39" src="https://user-images.githubusercontent.com/33497058/199117972-92acd7af-c0c9-4cfa-aada-e1ed2d0e27b4.png">
<img width="892" alt="Screenshot 2022-10-31 at 15 50 32" src="https://user-images.githubusercontent.com/33497058/199117976-74c3d68c-3afe-40a5-a8e5-1fc7a426fa9f.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>