### PR TITLE
Decrease Login Title size to have a better alignment

### DIFF
--- a/src/components/LoginWrapper/LoginWrapper.tsx
+++ b/src/components/LoginWrapper/LoginWrapper.tsx
@@ -82,7 +82,7 @@ const CustomLogin = styled.div(({ theme }) => {
         transform: "translateX(-50%)",
         "& .promoHeader": {
           color: get(theme, "login.promoHeader", "#fff"),
-          fontSize: "50px",
+          fontSize: "46px",
           textAlign: "left",
           fontWeight: "900",
           lineHeight: "60px",


### PR DESCRIPTION
## What does this do?

Decrease Login Title size to have a better alignment

## How does it look?

<img width="1664" alt="Screenshot 2023-01-03 at 11 51 39" src="https://user-images.githubusercontent.com/33497058/210413855-f38ab9d5-98c1-4e3b-b240-d733fff9d1ab.png">


Signed-off-by: Benjamin Perez <benjamin@bexsoft.net>