### PR TITLE
Added ScreenTitle Component as well as some adjustments

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -20,7 +20,7 @@ import { CSSObject } from "styled-components";
 export interface BreadcrumbsProps {
   sx?: CSSObject;
   children: React.ReactNode;
-  additionalOptions: React.ReactNode;
+  additionalOptions?: React.ReactNode;
   goBackFunction: () => void;
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,6 +18,7 @@ import React, { FC, Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
 import { ButtonProps, ConstructProps } from "./Button.types";
+import { breakPoints } from "../../global/utils";
 
 const CustomButton = styled.button<
   ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement> & ConstructProps
@@ -54,7 +55,7 @@ const CustomButton = styled.button<
       ((label && label.trim() !== "") || parentChildren)
     ) {
       smallScreenStyles = {
-        "@media (max-width: 768px)": {
+        [`@media (max-width: ${get(breakPoints, "md", 0)}px)`]: {
           padding: "0 14px",
           "& .button-label": {
             display: "none",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -56,15 +56,7 @@ const CheckboxItem = styled.label<InputLabelProps>(({ sx, theme }) => ({
 
 const Checkbox: FC<
   CheckboxProps & React.InputHTMLAttributes<HTMLInputElement>
-> = ({
-  tooltip,
-  label,
-  id,
-  overrideLabelClasses,
-  overrideCheckboxStyles,
-  className,
-  ...props
-}) => {
+> = ({ tooltip, label, id, overrideLabelClasses, sx, className, ...props }) => {
   return (
     <FieldContainer
       className={`inputItem ${className ? className : ""}`}
@@ -76,7 +68,7 @@ const Checkbox: FC<
         flexWrap: "nowrap",
       }}
     >
-      <CheckboxItem sx={overrideCheckboxStyles}>
+      <CheckboxItem sx={sx}>
         <input type={"checkbox"} id={id} {...props} />
         <span className={"checkbox"} />
       </CheckboxItem>
@@ -89,16 +81,14 @@ const Checkbox: FC<
             marginLeft: 10,
           }}
         >
-          <span>
-            {label}
-            {tooltip && tooltip !== "" && (
-              <div className={"tooltipContainer"}>
-                <Tooltip tooltip={tooltip} placement="top">
-                  <HelpIcon />
-                </Tooltip>
-              </div>
-            )}
-          </span>
+          {label}
+          {tooltip && tooltip !== "" && (
+            <div className={"tooltipContainer"}>
+              <Tooltip tooltip={tooltip} placement="top">
+                <HelpIcon />
+              </Tooltip>
+            </div>
+          )}
         </InputLabel>
       )}
     </FieldContainer>

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -36,10 +36,10 @@ const Template: Story<DataTableProps> = (args) => {
     const value = targetD.value;
     const checked = targetD.checked;
 
-    let elements: string[] = [...selected]; // We clone the selectedBuckets array
+    let elements: string[] = [...selected]; // We clone the selected array
 
     if (checked) {
-      // If the user has checked this field we need to push this to selectedBucketsList
+      // If the user has checked this field we need to push this to elements selection list
       elements.push(value);
     } else {
       // User has unchecked this field, we need to remove it from the list
@@ -212,4 +212,63 @@ CustomPaperHeight.args = {
       elementKey: "field3",
     },
   ],
+};
+
+export const CustomStyles = Template.bind({});
+CustomStyles.args = {
+  disabled: false,
+  entityName: "Elements",
+  idField: "field1",
+  customPaperHeight: "250px",
+  records: [
+    { field1: "Value1", field2: "Value2", field3: "Value3" },
+    {
+      field1: "Value1-1",
+      field2: "Value2-1",
+      field3: "Value3-1",
+    },
+  ],
+  columns: [
+    { label: "Column1", elementKey: "field1", width: 200 },
+    { label: "Column2", elementKey: "field2", width: 100 },
+    {
+      label: "Column3",
+      elementKey: "field3",
+    },
+  ],
+  sx: {
+    backgroundColor: "#f09",
+    color: "#fff",
+  },
+};
+
+export const WithSortIndicators = Template.bind({});
+WithSortIndicators.args = {
+  disabled: false,
+  entityName: "Elements",
+  idField: "field1",
+  customPaperHeight: "250px",
+  records: [
+    { field1: "Value1", field2: "Value2", field3: "Value3" },
+    {
+      field1: "Value1-1",
+      field2: "Value2-1",
+      field3: "Value3-1",
+    },
+  ],
+  columns: [
+    { label: "Column1", elementKey: "field1", width: 200 },
+    { label: "Column2", elementKey: "field2", width: 100 },
+    {
+      label: "Column3",
+      elementKey: "field3",
+    },
+  ],
+  sortConfig: {
+    currentSort: "field1",
+    currentDirection: "DESC",
+    triggerSort: () => {
+      alert("sort triggered");
+    },
+  },
 };

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -31,7 +31,7 @@ import {
 } from "./DataTable.utils";
 
 const DataTableWrapper = styled.div<DataTableWrapperProps>(
-  ({ theme, customPaperHeight, disabled, noBackground }) => ({
+  ({ theme, customPaperHeight, disabled, noBackground, sx }) => ({
     display: "flex",
     overflow: "auto",
     flexDirection: "column",
@@ -149,6 +149,12 @@ const DataTableWrapper = styled.div<DataTableWrapperProps>(
       "&:first-of-type": {
         marginLeft: 10,
       },
+      "& svg": {
+        width: 12,
+        height: 12,
+        marginRight: 5,
+        alignSelf: "flex-end",
+      },
     },
     "& .ReactVirtualized__Table__rowColumn": {
       marginRight: 10,
@@ -198,6 +204,7 @@ const DataTableWrapper = styled.div<DataTableWrapperProps>(
       left: 0,
       top: 3,
     },
+    ...sx,
   })
 );
 
@@ -236,11 +243,12 @@ const DataTable: FC<DataTableProps> = ({
   onSelectAll,
   rowStyle,
   parentClassName = "",
+  sx,
 }) => {
   /* TODO: Enable Columns Selection Capability
-        const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
-        const [anchorEl, setAnchorEl] = React.useState<any>(null);
-    */
+          const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
+          const [anchorEl, setAnchorEl] = React.useState<any>(null);
+      */
   const rowIDField = idField || "";
 
   const findView = itemActions
@@ -268,70 +276,71 @@ const DataTable: FC<DataTableProps> = ({
 
   /* TODO: Enable Columns Selection Capability
 
-            const openColumnsSelector = (event: { currentTarget: any }) => {
-                setColumnSelectorOpen(!columnSelectorOpen);
-                setAnchorEl(event.currentTarget);
-            };
+              const openColumnsSelector = (event: { currentTarget: any }) => {
+                  setColumnSelectorOpen(!columnSelectorOpen);
+                  setAnchorEl(event.currentTarget);
+              };
 
-            const closeColumnSelector = () => {
-                setColumnSelectorOpen(false);
-                setAnchorEl(null);
-            };
+              const closeColumnSelector = () => {
+                  setColumnSelectorOpen(false);
+                  setAnchorEl(null);
+              };
 
 
-              const columnsSelection = (columns: IColumns[]) => {
-                return (
-                  <Fragment>
-                    <IconButton
-                      aria-describedby={"columnsSelector"}
-                      color="primary"
-                      onClick={openColumnsSelector}
-                      size="large"
-                    >
-                      <ViewColumnIcon />
-                    </IconButton>
-                    <Popover
-                      anchorEl={anchorEl}
-                      id={"columnsSelector"}
-                      open={columnSelectorOpen}
-                      anchorOrigin={{
-                        vertical: "bottom",
-                        horizontal: "left",
-                      }}
-                      transformOrigin={{
-                        vertical: "top",
-                        horizontal: "left",
-                      }}
-                      onClose={closeColumnSelector}
-                    >
-                      <div className={classes.shownColumnsLabel}>Shown Columns</div>
-                      <div className={classes.popoverContent}>
-                        {columns.map((column: IColumns) => {
-                          return (
-                            <Checkbox
-                              key={`tableColumns-${column.label}`}
-                              label={column.label}
-                              checked={columnsShown.includes(column.elementKey!)}
-                              onChange={(e) => {
-                                onColumnChange(column.elementKey!, e.target.checked);
-                              }}
-                              id={`chbox-${column.label}`}
-                              name={`chbox-${column.label}`}
-                              value={column.label}
-                            />
-                          );
-                        })}
-                      </div>
-                    </Popover>
-                  </Fragment>
-                );
-              };*/
+                const columnsSelection = (columns: IColumns[]) => {
+                  return (
+                    <Fragment>
+                      <IconButton
+                        aria-describedby={"columnsSelector"}
+                        color="primary"
+                        onClick={openColumnsSelector}
+                        size="large"
+                      >
+                        <ViewColumnIcon />
+                      </IconButton>
+                      <Popover
+                        anchorEl={anchorEl}
+                        id={"columnsSelector"}
+                        open={columnSelectorOpen}
+                        anchorOrigin={{
+                          vertical: "bottom",
+                          horizontal: "left",
+                        }}
+                        transformOrigin={{
+                          vertical: "top",
+                          horizontal: "left",
+                        }}
+                        onClose={closeColumnSelector}
+                      >
+                        <div className={classes.shownColumnsLabel}>Shown Columns</div>
+                        <div className={classes.popoverContent}>
+                          {columns.map((column: IColumns) => {
+                            return (
+                              <Checkbox
+                                key={`tableColumns-${column.label}`}
+                                label={column.label}
+                                checked={columnsShown.includes(column.elementKey!)}
+                                onChange={(e) => {
+                                  onColumnChange(column.elementKey!, e.target.checked);
+                                }}
+                                id={`chbox-${column.label}`}
+                                name={`chbox-${column.label}`}
+                                value={column.label}
+                              />
+                            );
+                          })}
+                        </div>
+                      </Popover>
+                    </Fragment>
+                  );
+                };*/
 
   return (
     <Grid item xs={12} className={parentClassName}>
       <DataTableWrapper
         className={`${noBackground ? "noBackground" : ""}`}
         customPaperHeight={customPaperHeight}
+        sx={sx}
       >
         {isLoading && (
           <Grid container className={"loadingBox"}>

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { HTMLAttributes } from "react";
+import { CSSObject } from "styled-components";
 
 export interface ItemActions {
   label?: string;
@@ -80,12 +81,14 @@ export interface DataTableProps {
     index: number;
   }) => "deleted" | "" | React.CSSProperties;
   parentClassName?: string;
+  sx?: CSSObject;
 }
 
 export interface DataTableWrapperProps extends HTMLAttributes<HTMLDivElement> {
   disabled?: boolean;
   customPaperHeight?: string | number;
   noBackground?: boolean;
+  sx?: CSSObject;
 }
 
 export interface IActionButton {

--- a/src/components/InputBox/InputBox.tsx
+++ b/src/components/InputBox/InputBox.tsx
@@ -61,38 +61,41 @@ const InputBase = styled.input<InputBoxProps>(({ theme, error }) => {
   };
 });
 
-const InputContainer = styled.div<InputContainerProps>(({ theme, error }) => ({
-  display: "flex",
-  flexGrow: 1,
-  width: "100%",
-  "& .errorText": {
-    fontSize: 12,
-    color: get(theme, "inputBox.error", "#C51B3F"),
-    marginTop: 3,
-  },
-  "& .textBoxContainer": {
-    width: "100%",
-    flexGrow: 1,
-    position: "relative",
-    minWidth: 160,
-  },
-  "& .tooltipContainer": {
-    marginLeft: 5,
+const InputContainer = styled.div<InputContainerProps>(
+  ({ theme, error, sx }) => ({
     display: "flex",
-    alignItems: "center",
-    "& .min-icon": {
-      width: 13,
+    flexGrow: 1,
+    width: "100%",
+    "& .errorText": {
+      fontSize: 12,
+      color: get(theme, "inputBox.error", "#C51B3F"),
+      marginTop: 3,
     },
-  },
-  "& .overlayAction": {
-    position: "absolute",
-    right: 5,
-    top: 6,
-  },
-  "& .inputLabel": {
-    marginBottom: error ? 18 : 0,
-  },
-}));
+    "& .textBoxContainer": {
+      width: "100%",
+      flexGrow: 1,
+      position: "relative",
+      minWidth: 160,
+    },
+    "& .tooltipContainer": {
+      marginLeft: 5,
+      display: "flex",
+      alignItems: "center",
+      "& .min-icon": {
+        width: 13,
+      },
+    },
+    "& .overlayAction": {
+      position: "absolute",
+      right: 5,
+      top: 6,
+    },
+    "& .inputLabel": {
+      marginBottom: error ? 18 : 0,
+    },
+    ...sx,
+  })
+);
 
 const InputBox: FC<InputBoxProps> = ({
   id,

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -28,7 +28,7 @@ const CustomLabel = styled.label<InputLabelProps>(({ theme, sx }) => ({
   alignItems: "center",
   display: "flex",
   userSelect: "none",
-  "& span": {
+  "& > span": {
     display: "flex",
     alignItems: "center",
     minWidth: 160,

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { PageHeaderProps } from "./PageHeader.types";
 import Grid from "../Grid/Grid";
+import { breakPoints } from "../../global/utils";
 
 const ParentContainer = styled.div<HTMLAttributes<HTMLDivElement>>(
   ({ theme }) => ({
@@ -32,7 +33,7 @@ const ParentContainer = styled.div<HTMLAttributes<HTMLDivElement>>(
     flexWrap: "wrap",
     justifyContent: "space-between",
     alignItems: "center",
-    "@media (max-width: 768px)": {
+    [`@media (max-width: ${get(breakPoints, "md", 0)}px)`]: {
       "& > div": {
         margin: "4px 0",
         padding: "0 20px,",

--- a/src/components/ScreenTitle/ScreenTitle.stories.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.stories.tsx
@@ -1,0 +1,151 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Fragment } from "react";
+import { Meta, Story } from "@storybook/react";
+
+import ScreenTitle from "./ScreenTitle";
+import { ScreenTitleProps } from "./ScreenTitle.types";
+
+import StoryThemeProvider from "../../utils/StoryThemeProvider";
+import { GlobalStyles } from "../index";
+import SectionTitle from "../SectionTitle/SectionTitle";
+import Button from "../Button/Button";
+import TestIcon from "../../utils/TestIcon";
+
+export default {
+  title: "MDS/Layout/ScreenTitle",
+  component: ScreenTitle,
+  argTypes: {},
+} as Meta<typeof ScreenTitle>;
+
+const Template: Story<ScreenTitleProps> = (args) => (
+  <StoryThemeProvider>
+    <GlobalStyles />
+    <ScreenTitle {...args} />
+  </StoryThemeProvider>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  title: "Object Title",
+  subTitle: (
+    <Fragment>
+      <span>
+        Some Variable: <strong>Variable value</strong>
+      </span>
+      <span>
+        Some Variable: <strong>Variable value</strong>
+      </span>
+      <span>
+        Some Variable: <strong>Variable value</strong>
+      </span>
+    </Fragment>
+  ),
+  actions: (
+    <Fragment>
+      <Button id={"testButton1"}>Button1</Button>
+      <Button id={"testButton2"} variant={"callAction"}>
+        Button2
+      </Button>
+      <Button id={"testButton3"} variant={"secondary"}>
+        Button3
+      </Button>
+    </Fragment>
+  ),
+  icon: <TestIcon />,
+};
+
+export const NoIcon = Template.bind({});
+NoIcon.args = {
+  title: "Object Title",
+  subTitle: (
+    <Fragment>
+      <span>
+        Some Variable: <strong>Variable value</strong>
+      </span>
+    </Fragment>
+  ),
+  actions: (
+    <Fragment>
+      <Button id={"testButton1"}>Button1</Button>
+      <Button id={"testButton2"} variant={"callAction"}>
+        Button2
+      </Button>
+      <Button id={"testButton3"} variant={"secondary"}>
+        Button3
+      </Button>
+    </Fragment>
+  ),
+};
+
+export const NoBottomBorder = Template.bind({});
+NoBottomBorder.args = {
+  title: "Object Title",
+  subTitle: (
+    <Fragment>
+      <span>
+        Some Variable: <strong>Variable value</strong>
+      </span>
+    </Fragment>
+  ),
+  actions: (
+    <Fragment>
+      <Button id={"testButton1"}>Button1</Button>
+      <Button id={"testButton2"} variant={"callAction"}>
+        Button2
+      </Button>
+      <Button id={"testButton3"} variant={"secondary"}>
+        Button3
+      </Button>
+    </Fragment>
+  ),
+  icon: <TestIcon />,
+  bottomBorder: false,
+};
+
+export const CustomStyles = Template.bind({});
+CustomStyles.args = {
+  title: "Object Title",
+  subTitle: (
+    <Fragment>
+      <span>
+        Some Variable: <strong>Variable value</strong>
+      </span>
+    </Fragment>
+  ),
+  actions: (
+    <Fragment>
+      <Button id={"testButton1"}>Button1</Button>
+      <Button id={"testButton2"} variant={"callAction"}>
+        Button2
+      </Button>
+      <Button id={"testButton3"} variant={"secondary"}>
+        Button3
+      </Button>
+    </Fragment>
+  ),
+  icon: <TestIcon />,
+  sx: {
+    backgroundColor: "#090",
+    "& .headerBarSubheader": {
+      color: "#ff0",
+    },
+    "& .headerBarIcon .min-icon": {
+      fill: "#fff",
+    },
+  },
+};

--- a/src/components/ScreenTitle/ScreenTitle.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.tsx
@@ -1,0 +1,119 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { FC } from "react";
+import {
+  ScreenTitleContainerProps,
+  ScreenTitleProps,
+} from "./ScreenTitle.types";
+import styled from "styled-components";
+import Box from "../Box/Box";
+import get from "lodash/get";
+import { breakPoints } from "../../global/utils";
+
+const ScreenTitleContainer = styled.div<ScreenTitleContainerProps>(
+  ({ theme, sx, bottomBorder }) => ({
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "row",
+    flexWrap: "wrap",
+    width: "100%",
+    "& .stContainer": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: 8,
+      width: "100%",
+      borderBottom: !bottomBorder
+        ? "none"
+        : `1px solid ${get(theme, `screenTitle.border`, "#E5E5E5")}`,
+    },
+    "& .headerBarIcon": {
+      color: get(theme, `screenTitle.iconColor`, "#000"),
+      "& .min-icon": {
+        width: 44,
+        height: 44,
+      },
+    },
+    "& .headerBarSubheader": {
+      color: get(theme, `screenTitle.subtitleColor`, "#5B5C5C"),
+    },
+    "& .titleColumn": {
+      height: "auto",
+      justifyContent: "center",
+      display: "flex",
+      flexFlow: "column",
+      alignItems: "flex-start",
+      "& h1": {
+        fontSize: 20,
+      },
+    },
+    "& .leftItems": {
+      display: "flex",
+      alignItems: "center",
+      gap: 12,
+    },
+    "& .rightItems": {
+      display: "flex",
+      alignItems: "center",
+      gap: 10,
+    },
+    [`@media (max-width: ${get(breakPoints, "md", 0)}px)`]: {
+      "& .stContainer": {
+        flexDirection: "column",
+        gap: 12,
+        flexFlow: "column",
+        alignItems: "flex-start",
+      },
+      "& .headerBarIcon": { display: "none" },
+      "& .headerBarSubheader": {
+        display: "flex",
+        flexDirection: "column",
+      },
+      "& .rightItems": {
+        width: "100%",
+        justifyContent: "center",
+      },
+    },
+    ...sx,
+  })
+);
+
+const ScreenTitle: FC<ScreenTitleProps> = ({
+  icon,
+  subTitle,
+  title,
+  actions,
+  bottomBorder = true,
+  sx,
+}) => {
+  return (
+    <ScreenTitleContainer sx={sx} bottomBorder={bottomBorder}>
+      <Box className={"stContainer"}>
+        <Box className={"leftItems"}>
+          {icon ? <Box className={"headerBarIcon"}>{icon}</Box> : null}
+          <Box className={"titleColumn"}>
+            <h1 style={{ margin: 0 }}>{title}</h1>
+            <span className={"headerBarSubheader"}>{subTitle}</span>
+          </Box>
+        </Box>
+        <Box className={"rightItems"}>{actions}</Box>
+      </Box>
+    </ScreenTitleContainer>
+  );
+};
+
+export default ScreenTitle;

--- a/src/components/ScreenTitle/ScreenTitle.types.ts
+++ b/src/components/ScreenTitle/ScreenTitle.types.ts
@@ -1,5 +1,5 @@
 // This file is part of MinIO Design System
-// Copyright (c) 2023 MinIO, Inc.
+// Copyright (c) 2022 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,12 +14,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { HTMLAttributes } from "react";
+import React from "react";
 import { CSSObject } from "styled-components";
 
-export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
-  label?: string;
-  tooltip?: string;
-  overrideLabelClasses?: string;
+export interface ScreenTitleProps {
+  icon: React.ReactNode;
+  subTitle: React.ReactNode;
+  title: string;
+  actions: React.ReactNode;
   sx?: CSSObject;
+  bottomBorder?: boolean;
+}
+
+export interface ScreenTitleContainerProps {
+  sx?: CSSObject;
+  bottomBorder?: boolean;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,7 @@ export { default as InputBox } from "./InputBox/InputBox";
 export { default as Breadcrumbs } from "./Breadcrumbs/Breadcrumbs";
 export { default as ActionsList } from "./ActionsList/ActionsList";
 export { default as SimpleHeader } from "./SimpleHeader/SimpleHeader";
+export { default as ScreenTitle } from "./ScreenTitle/ScreenTitle";
 
 /*Icons*/
 export * from "./Icons";

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -111,6 +111,12 @@ export interface ActionsListThemeProps {
   disabledOptionsTextColor: string;
 }
 
+export interface ScreenTitleThemeProps {
+  border: string;
+  subtitleColor: string;
+  iconColor: string;
+}
+
 export interface ThemeDefinitionProps {
   bgColor: string;
   fontColor: string;
@@ -137,4 +143,5 @@ export interface ThemeDefinitionProps {
   inputBox: InputBoxThemeProps;
   breadcrumbs: BreadcrumbsThemeProps;
   actionsList: ActionsListThemeProps;
+  screenTitle: ScreenTitleThemeProps;
 }

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -298,6 +298,11 @@ export const lightTheme: ThemeDefinitionProps = {
     optionsTextColor: lightColors.optionTextColor,
     titleColor: lightColors.defaultFontColor,
   },
+  screenTitle: {
+    border: lightColors.borderColor,
+    subtitleColor: lightColors.commonLinkColor,
+    iconColor: lightColors.mainBlue,
+  },
 };
 
 export const darkTheme: ThemeDefinitionProps = {
@@ -484,5 +489,10 @@ export const darkTheme: ThemeDefinitionProps = {
     optionsHoverTextColor: darkColors.hoverWhite,
     optionsTextColor: darkColors.defaultFontColor,
     titleColor: darkColors.defaultFontColor,
+  },
+  screenTitle: {
+    border: darkColors.borderColor,
+    subtitleColor: darkColors.hoverGrey,
+    iconColor: darkColors.mainGrey,
   },
 };


### PR DESCRIPTION
## What does this do?
Added ScreenTitle Component as well as the following adjustments:
- Fixed sx var in InputBox
- Fixed Breadcrumbs types
- Adjusted size of sort arrow in data table
- Changed checkbox override props
- Fixed input label issue

## How does it look?

<img width="1498" alt="Screenshot 2023-04-17 at 15 21 13" src="https://user-images.githubusercontent.com/33497058/232614743-5dbfe364-4ac9-4a0f-8034-31a3b2ca27b2.png">
<img width="1498" alt="Screenshot 2023-04-17 at 15 21 06" src="https://user-images.githubusercontent.com/33497058/232614748-c80675e7-67c6-4e2f-9e45-82e7730a40c9.png">
<img width="1497" alt="Screenshot 2023-04-17 at 15 21 00" src="https://user-images.githubusercontent.com/33497058/232614750-94b5ccea-df43-4b3b-b34b-3050996714bd.png">
<img width="1500" alt="Screenshot 2023-04-17 at 15 04 33" src="https://user-images.githubusercontent.com/33497058/232614755-bb601d54-85c4-494e-ad30-2c3dbc70206d.png">
<img width="1505" alt="Screenshot 2023-04-17 at 15 04 24" src="https://user-images.githubusercontent.com/33497058/232614756-3eadfdaa-8ee5-43d1-8f69-7a9cf1797cd5.png">
<img width="501" alt="Screenshot 2023-04-17 at 15 04 03" src="https://user-images.githubusercontent.com/33497058/232614761-f7929964-b501-41c1-b2ad-878302e19e1e.png">
