### PR TITLE
Removed select text capability to RadioGroup labels

### DIFF
--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -74,6 +74,7 @@ const OptionsContainer = styled.div<OptionsContainerProps>(({ inColumn }) => ({
   justifyContent: "flex-end",
   gap: 15,
   "& .optionLabel": {
+    userSelect: "none",
     "&.checked": {
       fontWeight: "bold",
     },


### PR DESCRIPTION
## What does this do?

Removed select text capability to RadioGroup labels