### PR TITLE
Display DataTable actions in row

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -272,3 +272,51 @@ WithSortIndicators.args = {
     },
   },
 };
+
+export const WithItemActions = Template.bind({});
+WithItemActions.args = {
+  disabled: false,
+  entityName: "Elements",
+  idField: "field1",
+  customPaperHeight: "250px",
+  itemActions: [
+    {
+      type: "edit",
+      onClick: (itemID: string) => {
+        alert(itemID);
+      },
+      sendOnlyId: true,
+      label: "Edit",
+    },
+    {
+      type: "delete",
+      onClick: (deleteItem) => {
+        console.log("DELETE", deleteItem);
+      },
+      label: "Delete",
+    },
+  ],
+  records: [
+    { field1: "Value1", field2: "Value2", field3: "Value3" },
+    {
+      field1: "Value1-1",
+      field2: "Value2-1",
+      field3: "Value3-1",
+    },
+  ],
+  columns: [
+    { label: "Column1", elementKey: "field1", width: 200 },
+    { label: "Column2", elementKey: "field2", width: 100 },
+    {
+      label: "Column3",
+      elementKey: "field3",
+    },
+  ],
+  sortConfig: {
+    currentSort: "field1",
+    currentDirection: "DESC",
+    triggerSort: () => {
+      alert("sort triggered");
+    },
+  },
+};

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -179,7 +179,8 @@ const DataTableWrapper = styled.div<DataTableWrapperProps>(
       fill: "currentColor",
     },
     "& .optionsAlignment": {
-      textAlign: "center",
+      display: "flex",
+      gap: 5,
       "& .min-icon": {
         width: 16,
         height: 16,
@@ -517,7 +518,7 @@ const DataTable: FC<DataTableProps> = ({
                       {hasOptions && (
                         // @ts-ignore
                         <Column
-                          dataKey={rowIDField || "column-options"}
+                          dataKey={"column-options"}
                           width={optionsWidth}
                           headerClassName="optionsAlignment"
                           className="optionsAlignment"


### PR DESCRIPTION
## What does this do?

Fixes an issue where DataTable actions where shown in column instead of a row

## How does it look?

<img width="1729" alt="Screenshot 2023-05-24 at 15 14 06" src="https://github.com/minio/mds/assets/33497058/c1c55f9f-7d75-4a54-87bd-9577b6e75aca">
<img width="1736" alt="Screenshot 2023-05-24 at 15 12 02" src="https://github.com/minio/mds/assets/33497058/23ffc21a-0d24-4bfd-95e0-061a26b701f8">
