### PR TITLE
Fixed Application Logo crop on Safari

### DIFF
--- a/src/components/ApplicationLogo/Logos/Cloud/Cloud.tsx
+++ b/src/components/ApplicationLogo/Logos/Cloud/Cloud.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const Cloud: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 184.538 49.96" inverse={inverse}>
+    <LogoBase viewBox="0 0 184.538 52" inverse={inverse}>
       <g>
         <g>
           <rect

--- a/src/components/ApplicationLogo/Logos/SubnetOPS/SubnetOPS.tsx
+++ b/src/components/ApplicationLogo/Logos/SubnetOPS/SubnetOPS.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const DirectPV: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 665.85156 144.36321" inverse={inverse}>
+    <LogoBase viewBox="0 0 665.85156 145.5" inverse={inverse}>
       <g>
         <rect
           className={"minioSection"}


### PR DESCRIPTION
## What does this do?

Solves an issue with Cloud & Subnet OPS Application Logos, where they appeared cropped on Safari only.

## How does it look?

<img width="922" alt="Screenshot 2023-05-29 at 11 56 01" src="https://github.com/minio/mds/assets/33497058/306e98f2-c571-4107-8c7e-0fe57ab3f884">
<img width="730" alt="Screenshot 2023-05-29 at 11 55 46" src="https://github.com/minio/mds/assets/33497058/1d5bb2e7-623c-4156-9dc2-fd4a3be08a1d">
