### PR TITLE
Added Workaround for Safari specific issue with pointerevents and tooltips

### DIFF
--- a/src/components/ActionsList/ActionsList.tsx
+++ b/src/components/ActionsList/ActionsList.tsx
@@ -88,6 +88,9 @@ const ActionsList: FC<ActionsListProps> = ({ sx, items, title }) => {
                   icon={actionItem.icon}
                   onClick={actionItem.action}
                   disabled={actionItem.disabled}
+                  style={{
+                    pointerEvents: actionItem.disabled ? "none" : "initial",
+                  }}
                 />
               </Tooltip>
             </li>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -127,7 +127,7 @@ OnDisabledElement.args = {
   tooltip: <span>Some tooltip Label</span>,
   placement: "top",
   children: (
-    <Button id={"testButton"} disabled>
+    <Button id={"testButton"} disabled style={{ pointerEvents: "none" }}>
       Button
     </Button>
   ),


### PR DESCRIPTION
fixes https://github.com/minio/console/issues/2811

## What does this do?

There is a known issue with Safari & PointerEvents where they are not triggered on disabled elements.

Applied this WA to Actions List so we can avoid this issue on Safari. Other browsers work as expected.

## How does it look?

![2023-05-29 15-51-34 2023-05-29 15_52_19](https://github.com/minio/mds/assets/33497058/83d3c10f-3d98-4aa4-887b-f98f2fb86f43)
