### PR TITLE
Removed required iconComponent from HelpBox

### DIFF
--- a/src/components/HelpBox/HelpBox.stories.tsx
+++ b/src/components/HelpBox/HelpBox.stories.tsx
@@ -49,3 +49,8 @@ NoHelpText.args = {
   iconComponent: <TestIcon />,
   title: "Help Available for this page.",
 };
+
+export const NoIcon = Template.bind({});
+NoIcon.args = {
+  title: "Help Available for this page.",
+};

--- a/src/components/HelpBox/HelpBox.tsx
+++ b/src/components/HelpBox/HelpBox.tsx
@@ -51,7 +51,7 @@ const HelpBox: FC<HelpBoxProps> = ({ iconComponent, title, help }) => {
     <BaseHelpBox>
       <Grid container>
         <Grid item xs={12} className={"leftItems"}>
-          {iconComponent}
+          {iconComponent || null}
           {title}
         </Grid>
         {help && (

--- a/src/components/HelpBox/HelpBox.types.ts
+++ b/src/components/HelpBox/HelpBox.types.ts
@@ -17,7 +17,7 @@
 import React from "react";
 
 export interface HelpBoxProps {
-  iconComponent: any;
+  iconComponent?: any;
   title: string | React.ReactNode;
   help: any;
 }


### PR DESCRIPTION
## What does this do?

Removed iconComponent required prop from HelpBox

## How does it look?
<img width="1783" alt="Screenshot 2023-06-09 at 21 22 03" src="https://github.com/minio/mds/assets/33497058/9a8c73aa-eeba-412b-acef-bc8f7a99969e">

