### PR TITLE
Added Expand Options Button

### DIFF
--- a/src/components/ExpandOptionsButton/ExpandOptionsButton.stories.tsx
+++ b/src/components/ExpandOptionsButton/ExpandOptionsButton.stories.tsx
@@ -1,0 +1,79 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { useState } from "react";
+import { Meta, Story } from "@storybook/react";
+
+import ExpandOptionsButton from "./ExpandOptionsButton";
+import { ExpandOptionsButtonProps } from "./ExpandOptionsButton.types";
+
+import StoryThemeProvider from "../../utils/StoryThemeProvider";
+import GlobalStyles from "../GlobalStyles/GlobalStyles";
+import Box from "../Box/Box";
+
+export default {
+  title: "MDS/Forms/ExpandOptionsButton",
+  component: ExpandOptionsButton,
+  argTypes: {},
+} as Meta<typeof ExpandOptionsButton>;
+
+const Template: Story<ExpandOptionsButtonProps> = (args) => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const extraArgs = {
+    ...args,
+    open,
+    onClick: () => {
+      setOpen(!open);
+    },
+  };
+
+  return (
+    <StoryThemeProvider>
+      <GlobalStyles />
+      <ExpandOptionsButton {...extraArgs} />
+      {open && (
+        <Box withBorders sx={{ marginTop: 10 }}>
+          Simulated hidden panel
+        </Box>
+      )}
+    </StoryThemeProvider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  disabled: false,
+  label: "Click to Expand an Option",
+  variant: "regular",
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  disabled: true,
+  label: "Click to Expand an Option",
+  variant: "regular",
+};
+
+export const CustomStyles = Template.bind({});
+CustomStyles.args = {
+  label: "Click to Expand an Option",
+  variant: "regular",
+  sx: {
+    color: "#000",
+    backgroundColor: "#f90",
+  },
+};

--- a/src/components/ExpandOptionsButton/ExpandOptionsButton.tsx
+++ b/src/components/ExpandOptionsButton/ExpandOptionsButton.tsx
@@ -1,0 +1,84 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { FC } from "react";
+import styled from "styled-components";
+import get from "lodash/get";
+import {
+  ConstructExpandOptionsProps,
+  ExpandOptionsButtonProps,
+} from "./ExpandOptionsButton.types";
+import CollapseCaret from "../Icons/CollapseCaret";
+import ExpandCaret from "../Icons/ExpandCaret";
+import { lightColors } from "../../global/themes";
+
+const ExpandButtonBase = styled.button<ConstructExpandOptionsProps>(
+  ({ sx, theme }) => ({
+    display: "flex",
+    cursor: "pointer",
+    alignItems: "center",
+    backgroundColor: "transparent",
+    borderRadius: 3,
+    padding: 5,
+    height: 10,
+    fontSize: 10,
+    border: "none",
+    color: get(theme, "buttons.regular.enabled.text", lightColors.mainGrey),
+    "& svg": {
+      width: 16,
+      height: 16,
+    },
+    "&:hover": {
+      color: get(theme, "buttons.regular.hover.text", lightColors.mainGrey),
+      backgroundColor: get(
+        theme,
+        "buttons.regular.hover.background",
+        lightColors.hoverGrey
+      ),
+    },
+    "&:active": {
+      color: get(theme, "buttons.regular.pressed.text", lightColors.mainGrey),
+      backgroundColor: get(
+        theme,
+        "buttons.regular.pressed.background",
+        lightColors.pressedGrey
+      ),
+    },
+    "&:disabled": {
+      color: get(
+        theme,
+        "buttons.regular.disabled.text",
+        lightColors.disabledInnerGrey
+      ),
+      backgroundColor: "transparent",
+      cursor: "not-allowed",
+    },
+    ...sx,
+  })
+);
+
+const ExpandOptionsButton: FC<
+  ExpandOptionsButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({ open, label, sx, ...props }) => {
+  return (
+    <ExpandButtonBase sx={sx} {...props}>
+      {label}
+      {open ? <CollapseCaret /> : <ExpandCaret />}
+    </ExpandButtonBase>
+  );
+};
+
+export default ExpandOptionsButton;

--- a/src/components/ExpandOptionsButton/ExpandOptionsButton.types.ts
+++ b/src/components/ExpandOptionsButton/ExpandOptionsButton.types.ts
@@ -1,0 +1,28 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { CSSObject } from "styled-components";
+
+export interface ExpandOptionsButtonProps {
+  label: string;
+  open: boolean;
+  sx?: CSSObject;
+}
+
+export interface ConstructExpandOptionsProps {
+  sx?: CSSObject;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -53,6 +53,7 @@ export { default as RadioGroup } from "./RadioGroup/RadioGroup";
 export { default as ReadBox } from "./ReadBox/ReadBox";
 export { default as CommentBox } from "./CommentBox/CommentBox";
 export { default as Menu } from "./Menu/Menu";
+export { default as ExpandOptionsButton } from "./ExpandOptionsButton/ExpandOptionsButton";
 
 /*Icons*/
 export * from "./Icons";

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -175,6 +175,7 @@ export interface SignalColorsThemeProps {
   warning: string;
   good: string;
   info: string;
+  disabled: string;
 }
 
 export interface MenuThemeProps {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -172,6 +172,7 @@ export const lightTheme: ThemeDefinitionProps = {
     good: lightColors.mainGreen,
     info: lightColors.bulletColor,
     warning: lightColors.mainOrange,
+    disabled: lightColors.disabledGrey,
   },
   buttons: {
     regular: {
@@ -475,6 +476,7 @@ export const darkTheme: ThemeDefinitionProps = {
     good: darkColors.mainGreen,
     info: darkColors.secondActionHover,
     warning: darkColors.mainOrange,
+    disabled: darkColors.disabledGrey,
   },
   buttons: {
     regular: {


### PR DESCRIPTION
## What does this do?

Added an Expand Options Button to handle hidden filters and informative panels

## How does it look?

<img width="750" alt="Screenshot 2023-06-13 at 18 30 26" src="https://github.com/minio/mds/assets/33497058/3fc8a8fd-59d6-4f2c-b96c-900878109663">
<img width="1012" alt="Screenshot 2023-06-13 at 18 30 17" src="https://github.com/minio/mds/assets/33497058/3a4d9c90-e738-4662-a23e-005ae2c6b957">
<img width="787" alt="Screenshot 2023-06-13 at 18 30 06" src="https://github.com/minio/mds/assets/33497058/2b305391-9073-4115-98c3-3c7c02192851">
