### PR TITLE
Fixed some sizing issues with Application logos on Safari

### DIFF
--- a/src/components/ApplicationLogo/Logos/Console/ConsoleAGPL.tsx
+++ b/src/components/ApplicationLogo/Logos/Console/ConsoleAGPL.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const ConsoleAGPL: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 184.45 54.229" inverse={inverse}>
+    <LogoBase viewBox="0 0 184.45 55" inverse={inverse}>
       <g transform="translate(-31.65 -18.133)">
         <g transform="translate(-995 -63.754)">
           <g transform="translate(1025.5 81.887)">

--- a/src/components/ApplicationLogo/Logos/Console/ConsoleEnterprise.tsx
+++ b/src/components/ApplicationLogo/Logos/Console/ConsoleEnterprise.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const ConsoleEnterprise: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 184.45 50.008" inverse={inverse}>
+    <LogoBase viewBox="0 0 184.45 51" inverse={inverse}>
       <g transform="translate(-31.65 -18.133)">
         <g transform="translate(-995 -63.754)">
           <g transform="translate(1025.5 81.887)">

--- a/src/components/ApplicationLogo/Logos/Console/ConsoleSingle.tsx
+++ b/src/components/ApplicationLogo/Logos/Console/ConsoleSingle.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const ConsoleSingle: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 184.45 54.229" inverse={inverse}>
+    <LogoBase viewBox="0 0 184.45 55" inverse={inverse}>
       <g transform="translate(-31.65 -18.133)">
         <g transform="translate(-995 -63.754)">
           <g transform="translate(1025.5 81.887)">

--- a/src/components/ApplicationLogo/Logos/Console/ConsoleStandard.tsx
+++ b/src/components/ApplicationLogo/Logos/Console/ConsoleStandard.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const ConsoleStandard: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 184.538 50.008" inverse={inverse}>
+    <LogoBase viewBox="0 0 184.538 51" inverse={inverse}>
       <g transform="translate(-31.65 -18.133)">
         <g transform="translate(-995 -63.754)">
           <g transform="translate(1025.5 81.887)">

--- a/src/components/ApplicationLogo/Logos/KES/KES.tsx
+++ b/src/components/ApplicationLogo/Logos/KES/KES.tsx
@@ -20,7 +20,7 @@ import { LogoBaseProps } from "../LogoBase/LogoBase.types";
 
 const KES: FC<SVGProps<any> & LogoBaseProps> = ({ inverse }) => {
   return (
-    <LogoBase viewBox="0 0 184.538 50.008" inverse={inverse}>
+    <LogoBase viewBox="0 0 184.538 51" inverse={inverse}>
       <g transform="translate(26.059 -11)">
         <g transform="translate(-29 11)">
           <g transform="translate(0 0)">


### PR DESCRIPTION
## What does this do?

Fixed an issue with Application Logos in Safari

## How does it look?

<img width="1360" alt="Screenshot 2023-06-13 at 22 09 39" src="https://github.com/minio/mds/assets/33497058/72c02c78-d28a-4f11-b2d1-d997af2930be">
<img width="1352" alt="Screenshot 2023-06-13 at 22 09 20" src="https://github.com/minio/mds/assets/33497058/8457046f-1a17-47bd-a993-35a8c956d5cb">
<img width="1024" alt="Screenshot 2023-06-13 at 22 09 11" src="https://github.com/minio/mds/assets/33497058/46c0933f-3914-4107-829f-81806f39e5c2">
