### PR TITLE
Added new icons for audio settings

### DIFF
--- a/src/components/Icons/AudioIcon.tsx
+++ b/src/components/Icons/AudioIcon.tsx
@@ -1,0 +1,33 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as React from "react";
+import { SVGProps } from "react";
+
+const AudioIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={`min-icon`}
+    fill={"currentcolor"}
+    viewBox="0 0 256 256"
+    {...props}
+  >
+    <rect x="6" y="70.02" width="67.67" height="125.81" rx="12.39" ry="12.39" />
+    <path d="m104.5,68.4L238.61,15.81c6.29,0,11.39,5.1,11.39,11.39,0,0,0,0,0,0v201.6c0,6.29-5.1,11.39-11.39,11.39h0l-134.1-43.83c-8.98-3.41-11.4-5.1-11.4-11.39v-105.18c0-6.29,5.17-8.93,11.39-11.39Z" />
+  </svg>
+);
+
+export default AudioIcon;

--- a/src/components/Icons/AudioIconMute.tsx
+++ b/src/components/Icons/AudioIconMute.tsx
@@ -1,0 +1,46 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { SVGProps } from "react";
+
+const AudioIconMute = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={`min-icon`}
+      fill={"currentcolor"}
+      {...props}
+      viewBox="0 0 256 256"
+    >
+      <g id="a">
+        <g>
+          <path d="m178.39,178.92l-18.83-19.27c-3.23-3.27-3.23-8.53,0-11.8l19.55-20.02-19.56-20.02c-3.23-3.27-3.23-8.53,0-11.8l18.75-19.19c3.26-3.34,8.6-3.4,11.94-.15.05.05.1.1.15.15l8.77,8.98v-38.85h0c0-5.07-4.13-9.17-9.2-9.17l-108.27,42.29c-5.02,1.99-9.2,4.1-9.2,9.17v84.57c0,5.06,1.95,6.42,9.2,9.16l108.27,35.25c5.07,0,9.19-4.09,9.2-9.17v-39.19l-8.77,8.98c-3.31,3.29-8.65,3.33-12,.08Z" />
+          <rect
+            x="2.17"
+            y="81.37"
+            width="54.63"
+            height="101.16"
+            rx="13"
+            ry="13"
+          />
+        </g>
+        <path d="m228.81,127.93l25.02-25.61-18.74-19.81-22.77,22.66-2.86,2.93-24.99-25.59-19.38,19.19,22.29,23.43,2.73,2.8-25.02,25.61,18.75,19.81,22.77-22.66,2.86-2.93,25,25.59.32.13c.12,0,.23-.05.32-.13l18.74-19.19-22.29-23.43-2.73-2.8Z" />
+      </g>
+    </svg>
+  );
+};
+
+export default AudioIconMute;

--- a/src/components/Icons/CancelledAudioIcon.tsx
+++ b/src/components/Icons/CancelledAudioIcon.tsx
@@ -1,0 +1,47 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { SVGProps } from "react";
+
+const CancelledAudioIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={`min-icon`}
+      fill={"currentcolor"}
+      {...props}
+      viewBox="0 0 256 256"
+    >
+      <g id="a">
+        <g>
+          <path d="m109.41,92.6c-3.65,1.45-6.67,3-6.67,6.7v43.71l78.84-78.84-72.17,28.43Z" />
+          <path d="m91.29,106.48c0-7.07-5.73-12.8-12.8-12.8h-13.95c-7.07,0-12.8,5.73-12.8,12.8v48.52c0,7.07,5.73,12.8,12.8,12.8h13.4l13.35-13.35v-47.97Z" />
+          <path d="m129.7,174.51l58.21,19.11c3.69-.01,6.68-3.01,6.68-6.7v-77.29l-64.88,64.88Z" />
+        </g>
+        <path d="m128,1.64C58.22,1.64,1.65,58.21,1.64,128c0,69.78,56.57,126.36,126.35,126.36,69.78,0,126.36-56.57,126.36-126.35h0C254.36,58.22,197.78,1.65,128,1.64m.75,226.19c-55.13,0-99.83-44.7-99.83-99.83S73.62,28.17,128.75,28.17s99.83,44.7,99.83,99.83-44.7,99.83-99.83,99.83h0" />
+        <rect
+          x="30.31"
+          y="120.75"
+          width="221.82"
+          height="25.59"
+          transform="translate(-53.07 138.97) rotate(-45)"
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default CancelledAudioIcon;

--- a/src/components/Icons/ChatIcon.tsx
+++ b/src/components/Icons/ChatIcon.tsx
@@ -1,0 +1,32 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as React from "react";
+import { SVGProps } from "react";
+
+const ChatIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={`min-icon`}
+    fill={"currentcolor"}
+    viewBox="0 0 256 256"
+    {...props}
+  >
+    <path d="m33.27,219.82c.11-9.44-.8-18.86-2.72-28.1C12.27,185.4,0,168.18,0,148.84V45.34C0,20.3,20.3,0,45.34,0h161.65c25.04,0,45.34,20.3,45.34,45.34h0v103.5c0,25.04-20.3,45.34-45.34,45.34H74.85c-6.33,6.52-17.95,16.82-36.98,28.4-.45.28-.97.42-1.5.42-1.73-.02-3.11-1.44-3.09-3.17v-.02Z" />
+  </svg>
+);
+
+export default ChatIcon;

--- a/src/components/Icons/Icons.stories.tsx
+++ b/src/components/Icons/Icons.stories.tsx
@@ -145,6 +145,18 @@ const Template: Story = (args) => {
             </Grid>
 
             <Grid item xs={3} sm={2} md={1}>
+              <cicons.AudioIcon />
+              <br />
+              AudioIcon
+            </Grid>
+
+            <Grid item xs={3} sm={2} md={1}>
+              <cicons.AudioIconMute />
+              <br />
+              AudioIconMute
+            </Grid>
+
+            <Grid item xs={3} sm={2} md={1}>
               <cicons.AzureTierIcon />
               <br />
               AzureTierIcon
@@ -211,6 +223,12 @@ const Template: Story = (args) => {
             </Grid>
 
             <Grid item xs={3} sm={2} md={1}>
+              <cicons.CancelledAudioIcon />
+              <br />
+              CancelledAudioIcon
+            </Grid>
+
+            <Grid item xs={3} sm={2} md={1}>
               <cicons.CancelledIcon />
               <br />
               CancelledIcon
@@ -226,6 +244,12 @@ const Template: Story = (args) => {
               <cicons.ChangeAccessPolicyIcon />
               <br />
               ChangeAccessPolicyIcon
+            </Grid>
+
+            <Grid item xs={3} sm={2} md={1}>
+              <cicons.ChatIcon />
+              <br />
+              ChatIcon
             </Grid>
 
             <Grid item xs={3} sm={2} md={1}>
@@ -856,6 +880,12 @@ const Template: Story = (args) => {
               <cicons.SelectMultipleIcon />
               <br />
               SelectMultipleIcon
+            </Grid>
+
+            <Grid item xs={3} sm={2} md={1}>
+              <cicons.SendMessageIcon />
+              <br />
+              SendMessageIcon
             </Grid>
 
             <Grid item xs={3} sm={2} md={1}>

--- a/src/components/Icons/SendMessageIcon.tsx
+++ b/src/components/Icons/SendMessageIcon.tsx
@@ -1,0 +1,32 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as React from "react";
+import { SVGProps } from "react";
+
+const SendMessageIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={`min-icon`}
+    fill={"currentcolor"}
+    viewBox="0 0 256 256"
+    {...props}
+  >
+    <path d="m176.03,253.47c-3.13,0-6.22-.71-9.03-2.09-3.04-1.52-5.66-3.76-7.63-6.54l-57.42-79.52,59.8-59.8c2.64-2.63,2.65-6.89.02-9.53s-6.89-2.65-9.53-.02c0,0-.01.01-.02.02l-59.43,59.43L10.59,96.07c-1.65-1.19-3.13-2.6-4.39-4.21-1.16-1.49-2.11-3.14-2.81-4.9-1.33-3.39-1.75-7.07-1.2-10.68.54-3.67,2.03-7.14,4.33-10.07,2.39-3.03,5.61-5.31,9.26-6.57l-.49-.05L226.71,2.99l-.04.3c1.8-.51,3.66-.77,5.52-.77.87,0,1.74.06,2.6.17,2.62.23,5.16.96,7.5,2.16,2.79,1.43,5.23,3.46,7.14,5.94,1.87,2.44,3.19,5.26,3.84,8.27.35,1.63.49,3.29.44,4.95l.33-.07-.45,1.66c-.12,1.06-.32,2.11-.59,3.14l-36,134.88.04.04-15.2,54.72-5.99,22.33-.06-.56-.42,1.51-.1-.64c-1.62,3.8-4.37,7.01-7.88,9.2-3.4,2.13-7.34,3.27-11.35,3.26Z" />
+  </svg>
+);
+
+export default SendMessageIcon;

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -205,3 +205,8 @@ export { default as VisibilityOffIcon } from "./VisibilityOffIcon";
 export { default as AccessRuleIcon } from "./AccessRuleIcon";
 export { default as TimeIcon } from "./TimeIcon";
 export { default as CollapseMenuIcon } from "./CollapseMenuIcon";
+export { default as AudioIcon } from "./AudioIcon";
+export { default as AudioIconMute } from "./AudioIconMute";
+export { default as ChatIcon } from "./ChatIcon";
+export { default as SendMessageIcon } from "./SendMessageIcon";
+export { default as CancelledAudioIcon } from "./CancelledAudioIcon";


### PR DESCRIPTION
## What does this do?

Added new icons for Audio support

## How does it look?

<img width="150" alt="Screenshot 2023-06-19 at 17 49 31" src="https://github.com/minio/mds/assets/33497058/b8bd4048-5510-4a6c-b491-a208a549a975">
<img width="140" alt="Screenshot 2023-06-19 at 17 49 26" src="https://github.com/minio/mds/assets/33497058/d6dfd463-7db5-4317-a813-2ae6ceade3d8">
<img width="84" alt="Screenshot 2023-06-19 at 17 49 18" src="https://github.com/minio/mds/assets/33497058/596aaa71-1d5d-469f-aada-c09f8d217507">
<img width="289" alt="Screenshot 2023-06-19 at 17 49 10" src="https://github.com/minio/mds/assets/33497058/92378cb6-067e-4312-b46a-a4efdf80ba00">
