### PR TITLE
Fixed issue with Shown Columns title color on dark mode

### DIFF
--- a/src/components/DataTable/ColumnsSelector.tsx
+++ b/src/components/DataTable/ColumnsSelector.tsx
@@ -65,6 +65,7 @@ const SelectorBox = styled.div<ColumnSelectorConstructProps>(
         lightColors.borderColor
       )}`,
       marginBottom: 5,
+      color: get(theme, "fontColor", lightColors.defaultFontColor),
     },
     "& .columnsSelectorContainer": {
       display: "flex",


### PR DESCRIPTION
## What does this do?

Fixes an issue with Shown Column title in dark mode

## How does it look?

<img width="199" alt="Screenshot 2023-06-22 at 12 11 08" src="https://github.com/minio/mds/assets/33497058/aefe97c2-7dce-40d7-92d5-ae89b8848ddb">
