### PR TITLE
Added custom style colors to CodeEditor

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default [
       commonjs(),
       typescript({ tsconfig: "./tsconfig.json" }),
       terser(),
-      css(),
+      css({ alwaysOutput: true, minify: true }),
       copy({
         targets: [{ src: "src/components/assets", dest: "dist" }],
       }),

--- a/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -55,6 +55,7 @@ WithHelpTools.args = {
       />
     </Fragment>
   ),
+  mode: "js",
 };
 
 export const WithTooltip = Template.bind({});

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -40,17 +40,169 @@ const CodeEditorBase = styled.div<CodeEditorBaseProps>(
         width: 13,
       },
     },
-    "& .editor": {
-      fontSize: 12,
-      fontFamily:
-        "ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
-      minHeight: editorHeight || "initial",
-      backgroundColor: get(
-        theme,
-        "codeEditor.backgroundColor",
-        lightColors.white
-      ),
-      color: get(theme, "codeEditor.textColor", lightColors.defaultFontColor),
+    "& .mds-editor": {
+      "&.w-tc-editor": {
+        fontSize: 12,
+        backgroundColor: get(
+          theme,
+          "codeEditor.backgroundColor",
+          lightColors.white
+        ),
+        color: get(theme, "codeEditor.textColor", lightColors.defaultFontColor),
+        fontFamily:
+          "ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
+        minHeight: editorHeight || "initial",
+        [`& code[class*="language-"] .token.cdata,
+      & pre[class*="language-"] .token.cdata,
+      & code[class*="language-"] .token.comment,
+      & pre[class*="language-"] .token.comment,
+      & code[class*="language-"] .token.doctype,
+      & pre[class*="language-"] .token.doctype,
+      & code[class*="language-"] .token.prolog,
+      & pre[class*="language-"] .token.prolog`]: {
+          color: get(
+            theme,
+            "codeEditor.comment",
+            lightColors.codeEditorComment
+          ),
+        },
+        [`& code[class*="language-"] .token.punctuation,
+& pre[class*="language-"] .token.punctuation`]: {
+          color: get(
+            theme,
+            "codeEditor.sublimelinterGutterMark",
+            lightColors.codeEditorSublimelinterGutterMark
+          ),
+        },
+        [`& code[class*="language-"] .namespace,
+& pre[class*="language-"] .namespace`]: {
+          opacity: 0.7,
+        },
+        [`& code[class*="language-"] .token.boolean,
+& pre[class*="language-"] .token.boolean,
+& code[class*="language-"] .token.constant,
+& pre[class*="language-"] .token.constant,
+& code[class*="language-"] .token.deleted,
+& pre[class*="language-"] .token.deleted,
+& code[class*="language-"] .token.number,
+& pre[class*="language-"] .token.number,
+& code[class*="language-"] .token.symbol,
+& pre[class*="language-"] .token.symbol`]: {
+          color: get(
+            theme,
+            "codeEditor.entityTag",
+            lightColors.codeEditorEntityTag
+          ),
+        },
+        [`& code[class*="language-"] .token.builtin,
+& pre[class*="language-"] .token.builtin,
+& code[class*="language-"] .token.char,
+& pre[class*="language-"] .token.char,
+& code[class*="language-"] .token.inserted,
+& pre[class*="language-"] .token.inserted,
+& code[class*="language-"] .token.selector,
+& pre[class*="language-"] .token.selector,
+& code[class*="language-"] .token.string,
+& pre[class*="language-"] .token.string`]: {
+          color: get(
+            theme,
+            "codeEditor.constant",
+            lightColors.codeEditorConstant
+          ),
+        },
+        [`& code[class*="language-"] .style .token.string,
+& pre[class*="language-"] .style .token.string,
+& code[class*="language-"] .token.entity,
+& pre[class*="language-"] .token.entity,
+& code[class*="language-"] .token.property,
+& pre[class*="language-"] .token.property,
+& code[class*="language-"] .token.operator,
+& pre[class*="language-"] .token.operator,
+& code[class*="language-"] .token.url,
+& pre[class*="language-"] .token.url`]: {
+          color: get(
+            theme,
+            "codeEditor.constant",
+            lightColors.codeEditorConstant
+          ),
+        },
+        [`& code[class*="language-"] .token.atrule,
+& pre[class*="language-"] .token.atrule,
+& code[class*="language-"] .token.property-access .token.method,
+& pre[class*="language-"] .token.property-access .token.method,
+& code[class*="language-"] .token.keyword,
+& pre[class*="language-"] .token.keyword`]: {
+          color: get(
+            theme,
+            "codeEditor.keyword",
+            lightColors.codeEditorKeyword
+          ),
+        },
+        [`& code[class*="language-"] .token.function,
+& pre[class*="language-"] .token.function`]: {
+          color: get(theme, "codeEditor.string", lightColors.codeEditorString),
+        },
+
+        [`& code[class*="language-"] .token.important,
+& pre[class*="language-"] .token.important,
+& code[class*="language-"] .token.regex,
+& pre[class*="language-"] .token.regex,
+& code[class*="language-"] .token.variable,
+& pre[class*="language-"] .token.variable`]: {
+          color: get(
+            theme,
+            "codeEditor.codeEditorRegexp",
+            lightColors.codeEditorRegexp
+          ),
+        },
+        [`& code[class*="language-"] .token.bold,
+& pre[class*="language-"] .token.bold,
+& code[class*="language-"] .token.important,
+& pre[class*="language-"] .token.important`]: {
+          color: get(
+            theme,
+            "codeEditor.markupBold",
+            lightColors.codeEditorMarkupBold
+          ),
+        },
+        [`& code[class*="language-"] .token.tag,
+& pre[class*="language-"] .token.tag`]: {
+          color: get(
+            theme,
+            "codeEditor.entityTag",
+            lightColors.codeEditorEntityTag
+          ),
+        },
+        [`& code[class*="language-"] .token.attr-value,
+& pre[class*="language-"] .token.attr-value,
+& code[class*="language-"] .token.attr-name,
+& pre[class*="language-"] .token.attr-name`]: {
+          color: get(
+            theme,
+            "codeEditor.constant",
+            lightColors.codeEditorConstant
+          ),
+        },
+        [`& code[class*="language-"] .token.selector .class,
+& pre[class*="language-"] .token.selector .class,
+& code[class*="language-"] .token.class-name,
+& pre[class*="language-"] .token.class-name`]: {
+          color: get(theme, "codeEditor.entity", lightColors.codeEditorEntity),
+        },
+      },
+      "& .w-tc-editor-text, .w-tc-editor-preview": {
+        minHeight: 16,
+      },
+      "& .w-tc-editor-preview pre": {
+        margin: 0,
+        padding: 0,
+        whiteSpace: "inherit",
+        fontFamily: "inherit",
+        fontSize: "inherit",
+      },
+      "& .w-tc-editor-preview pre code": {
+        fontFamily: "inherit",
+      },
     },
     "& .actionsContainer": {
       display: "flex",
@@ -116,7 +268,7 @@ const CodeMirrorWrapper: FC<CodeEditorProps> = ({
           }}
           id={"code_wrapper"}
           padding={15}
-          className={"editor"}
+          className={"mds-editor"}
         />
       </Box>
       {helpTools && <Box className={"actionsContainer"}>{helpTools}</Box>}

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -241,6 +241,15 @@ export interface CodeEditorThemeProps {
   backgroundColor: string;
   textColor: string;
   helpToolsBarBG: string;
+  comment: string;
+  entityTag: string;
+  entity: string;
+  sublimelinterGutterMark: string;
+  constant: string;
+  string: string;
+  keyword: string;
+  markupBold: string;
+  codeEditorRegexp: string;
 }
 
 export interface ThemeDefinitionProps {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -88,6 +88,15 @@ export const lightColors = {
   menuIconBG: "#06274E",
   menuIconBorder: "#052148",
   tabBorder: "#EAEAEA",
+  codeEditorComment: "#6e7781",
+  codeEditorEntityTag: "#116329",
+  codeEditorEntity: "#8250df",
+  codeEditorSublimelinterGutterMark: "#8c959f",
+  codeEditorConstant: "#0550ae",
+  codeEditorString: "#0a3069",
+  codeEditorKeyword: "#cf222e",
+  codeEditorMarkupBold: "#24292f",
+  codeEditorRegexp: "#ffaa00",
 };
 
 export const darkColors = {
@@ -156,6 +165,15 @@ export const darkColors = {
   menuIconBorder: "#151E2E",
   menuHoverSelectedBorderIcon: "#0E1119",
   menuHoverSelectedBG: "#909AAB",
+  codeEditorComment: "#8b949e",
+  codeEditorEntityTag: "#7ee787",
+  codeEditorEntity: "#d2a8ff",
+  codeEditorSublimelinterGutterMark: "#8E98A9",
+  codeEditorConstant: "#79c0ff",
+  codeEditorString: "#a5d6ff",
+  codeEditorKeyword: "#ff7b72",
+  codeEditorMarkupBold: "#c9d1d9",
+  codeEditorRegexp: "#ffd582",
 };
 
 export const lightTheme: ThemeDefinitionProps = {
@@ -495,6 +513,15 @@ export const lightTheme: ThemeDefinitionProps = {
     backgroundColor: lightColors.white,
     textColor: lightColors.defaultFontColor,
     helpToolsBarBG: lightColors.boxBackground,
+    comment: lightColors.codeEditorComment,
+    entityTag: lightColors.codeEditorEntityTag,
+    entity: lightColors.codeEditorEntity,
+    sublimelinterGutterMark: lightColors.codeEditorSublimelinterGutterMark,
+    constant: lightColors.codeEditorConstant,
+    string: lightColors.codeEditorString,
+    keyword: lightColors.codeEditorKeyword,
+    markupBold: lightColors.codeEditorMarkupBold,
+    codeEditorRegexp: lightColors.codeEditorRegexp,
   },
 };
 
@@ -835,5 +862,14 @@ export const darkTheme: ThemeDefinitionProps = {
     backgroundColor: darkColors.boxBackground,
     textColor: darkColors.mainWhite,
     helpToolsBarBG: darkColors.boxBackground,
+    comment: darkColors.codeEditorComment,
+    entityTag: darkColors.codeEditorEntityTag,
+    entity: darkColors.codeEditorEntity,
+    sublimelinterGutterMark: darkColors.codeEditorSublimelinterGutterMark,
+    constant: darkColors.codeEditorConstant,
+    string: darkColors.codeEditorString,
+    keyword: darkColors.codeEditorKeyword,
+    markupBold: darkColors.codeEditorMarkupBold,
+    codeEditorRegexp: darkColors.codeEditorRegexp,
   },
 };


### PR DESCRIPTION
## What does this do?

Fixed some style issues & added custom colors capability to CodeEditor

## How does it look?

<img width="1125" alt="Screenshot 2023-06-27 at 15 13 33" src="https://github.com/minio/mds/assets/33497058/39fc8d0e-2e51-4177-8708-6be3d821658f">
<img width="1260" alt="Screenshot 2023-06-27 at 15 13 28" src="https://github.com/minio/mds/assets/33497058/2e976965-7abd-4b50-acc5-427bc1eca7b2">
