### PR TITLE
Updated select Arrow size

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -103,6 +103,8 @@ const InputContainer = styled.div<InputContainerProps>(
       marginTop: 2,
       right: 5,
       "& svg": {
+        width: 26,
+        height: 26,
         fill: get(theme, "inputBox.color", "#07193E"),
       },
     },


### PR DESCRIPTION
## What does this do?

Added fixed size to Select arrow in Select component

## How does it look?

<img width="979" alt="Screenshot 2023-07-08 at 11 39 33" src="https://github.com/minio/mds/assets/33497058/4b3841fa-502a-4999-93a8-4b7dbe26733e">
