### PR TITLE
DataTable improvements

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -21,6 +21,7 @@ import DataTable from "./DataTable";
 import { DataTableProps } from "./DataTable.types";
 import GlobalStyles from "../GlobalStyles/GlobalStyles";
 import Grid from "../Grid/Grid";
+import SuccessIcon from "../Icons/SuccessIcon";
 
 export default {
   title: "MDS/Information/DataTable",
@@ -314,14 +315,132 @@ WithItemActions.args = {
         alert(itemID);
       },
       sendOnlyId: true,
-      label: "Edit",
+      tooltip: "Edit",
     },
     {
       type: "delete",
       onClick: (deleteItem) => {
         console.log("DELETE", deleteItem);
       },
-      label: "Delete",
+      tooltip: "Delete",
+    },
+  ],
+  records: [
+    { field1: "Value1", field2: "Value2", field3: "Value3" },
+    {
+      field1: "Value1-1",
+      field2: "Value2-1",
+      field3: "Value3-1",
+    },
+  ],
+  columns: [
+    { label: "Column1", elementKey: "field1", width: 200 },
+    { label: "Column2", elementKey: "field2", width: 100 },
+    {
+      label: "Column3",
+      elementKey: "field3",
+    },
+  ],
+  sortConfig: {
+    currentSort: "field1",
+    currentDirection: "DESC",
+    triggerSort: () => {
+      alert("sort triggered");
+    },
+  },
+};
+
+export const FullItemsActions = Template.bind({});
+FullItemsActions.args = {
+  disabled: false,
+  entityName: "Elements",
+  idField: "field1",
+  customPaperHeight: "250px",
+  itemActions: [
+    {
+      type: "edit",
+      onClick: (itemID: string) => {
+        alert(itemID);
+      },
+      sendOnlyId: true,
+      tooltip: "Edit",
+    },
+    {
+      type: "delete",
+      onClick: (deleteItem) => {
+        console.log("DELETE", deleteItem);
+      },
+      tooltip: "Delete",
+    },
+    {
+      type: "console",
+      onClick: (deleteItem) => {
+        console.log("CONSOLE", deleteItem);
+      },
+      tooltip: "Console",
+    },
+    {
+      type: "description",
+      onClick: (deleteItem) => {
+        console.log("DESCRIPTION", deleteItem);
+      },
+      tooltip: "Description",
+    },
+    {
+      type: "cloud",
+      onClick: (deleteItem) => {
+        console.log("CLOUD", deleteItem);
+      },
+      tooltip: "Cloud",
+    },
+    {
+      type: "view",
+      onClick: (deleteItem) => {
+        console.log("VIEW", deleteItem);
+      },
+      tooltip: "View",
+    },
+    {
+      type: "disable",
+      onClick: (deleteItem) => {
+        console.log("DISABLE", deleteItem);
+      },
+      tooltip: "Disable",
+    },
+    {
+      type: "download",
+      onClick: (deleteItem) => {
+        console.log("DOWNLOAD", deleteItem);
+      },
+      tooltip: "Download",
+    },
+    {
+      type: "format",
+      onClick: (deleteItem) => {
+        console.log("FORMAT", deleteItem);
+      },
+      tooltip: "Format",
+    },
+    {
+      type: "preview",
+      onClick: (deleteItem) => {
+        console.log("PREVIEW", deleteItem);
+      },
+      tooltip: "Preview",
+    },
+    {
+      type: "share",
+      onClick: (deleteItem) => {
+        console.log("SHARE", deleteItem);
+      },
+      tooltip: "Share",
+    },
+    {
+      type: <SuccessIcon />,
+      onClick: (deleteItem) => {
+        console.log("DELETE", deleteItem);
+      },
+      tooltip: "Custom Icon",
     },
   ],
   records: [

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -17,9 +17,25 @@
 import React, { HTMLAttributes } from "react";
 import { CSSObject } from "styled-components";
 
+export const actionsTypes = [
+  "view",
+  "edit",
+  "delete",
+  "description",
+  "share",
+  "cloud",
+  "console",
+  "download",
+  "disable",
+  "format",
+  "preview",
+] as const;
+
+export type PredefinedActionTypes = (typeof actionsTypes)[number];
+
 export interface ItemActions {
-  label?: string;
-  type: string | any;
+  tooltip?: string;
+  type: PredefinedActionTypes | React.ReactNode;
   sendOnlyId?: boolean;
   disableButtonFunction?: (itemValue: any) => boolean;
   showLoaderFunction?: (itemValue: any) => boolean;
@@ -93,8 +109,8 @@ export interface DataTableWrapperProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export interface IActionButton {
-  label?: string;
-  type: string | React.ReactNode;
+  tooltip?: string;
+  type: PredefinedActionTypes | React.ReactNode;
   onClick?: (id: string) => any;
   valueToSend: any;
   selected: boolean;

--- a/src/components/DataTable/DataTable.utils.tsx
+++ b/src/components/DataTable/DataTable.utils.tsx
@@ -18,7 +18,12 @@ import React, { Fragment } from "react";
 import get from "lodash/get";
 import isString from "lodash/isString";
 import { Column } from "react-virtualized";
-import { IColumns, ItemActions } from "./DataTable.types";
+import {
+  IColumns,
+  ItemActions,
+  PredefinedActionTypes,
+  actionsTypes,
+} from "./DataTable.types";
 import ArrowDropUpIcon from "../Icons/ArrowDropUp";
 import ArrowDropDownIcon from "../Icons/ArrowDropDown";
 import Loader from "../Loader/Loader";
@@ -203,7 +208,7 @@ export const elementActions = (
 
     return (
       <TableActionButton
-        label={action.label}
+        tooltip={action.tooltip}
         type={action.type}
         onClick={action.onClick}
         valueToSend={valueToSend}
@@ -235,3 +240,6 @@ export const calculateOptionsSize = (
 
   return sizeOptions;
 };
+
+export const isPredefinedAction = (val: any): val is PredefinedActionTypes =>
+  actionsTypes.includes(val);

--- a/src/components/DataTable/TableActionButton.tsx
+++ b/src/components/DataTable/TableActionButton.tsx
@@ -27,9 +27,10 @@ import EditIcon from "../Icons/EditIcon";
 import TrashIcon from "../Icons/TrashIcon";
 import DownloadIcon from "../Icons/DownloadIcon";
 import IconButton from "../IconButton/IconButton";
-import { IActionButton } from "./DataTable.types";
+import { IActionButton, PredefinedActionTypes } from "./DataTable.types";
+import { isPredefinedAction } from "./DataTable.utils";
 
-const defineIcon = (type: string) => {
+const defineIcon = (type: PredefinedActionTypes) => {
   switch (type) {
     case "view":
       return <PreviewIcon />;
@@ -65,11 +66,11 @@ const TableActionButton: FC<IActionButton> = ({
   idField,
   sendOnlyId = false,
   disabled = false,
-  label,
+  tooltip,
 }) => {
   const valueClick = sendOnlyId ? valueToSend[idField] : valueToSend;
 
-  const icon = typeof type === "string" ? defineIcon(type) : type;
+  const icon = isPredefinedAction(type) ? defineIcon(type) : type;
   let buttonElement = (
     <IconButton
       type={"button"}
@@ -96,8 +97,8 @@ const TableActionButton: FC<IActionButton> = ({
     </IconButton>
   );
 
-  if (label && label !== "") {
-    buttonElement = <Tooltip tooltip={label}>{buttonElement}</Tooltip>;
+  if (tooltip && tooltip !== "") {
+    buttonElement = <Tooltip tooltip={tooltip}>{buttonElement}</Tooltip>;
   }
 
   if (onClick) {

--- a/src/components/Icons/Icons.stories.tsx
+++ b/src/components/Icons/Icons.stories.tsx
@@ -32,7 +32,13 @@ export default {
   argTypes: {},
 } as Meta;
 
-const IconDisplay = ({ children }: { children: ReactNode | ReactNode[] }) => {
+const IconDisplay = ({
+  children,
+  applyColor,
+}: {
+  children: ReactNode | ReactNode[];
+  applyColor: boolean;
+}) => {
   return (
     <Box
       style={{
@@ -49,6 +55,7 @@ const IconDisplay = ({ children }: { children: ReactNode | ReactNode[] }) => {
           wordBreak: "break-word",
           "& .min-icon": {
             height: 24,
+            color: applyColor ? "red" : "black",
           },
         },
       }}
@@ -78,7 +85,7 @@ const Template: Story = (args) => {
             </Button>
           </Grid>
           <h1>Icons</h1>
-          <IconDisplay>
+          <IconDisplay applyColor={color}>
             <div className="story-icon">
               <cicons.AccessRuleIcon />
               <br />
@@ -1183,7 +1190,7 @@ const Template: Story = (args) => {
             </div>
           </IconDisplay>
           <h1>Menu Icons</h1>
-          <IconDisplay>
+          <IconDisplay applyColor={color}>
             <div className="story-icon">
               <micons.AccessMenuIcon />
               <br />
@@ -1342,7 +1349,7 @@ const Template: Story = (args) => {
             </div>
           </IconDisplay>
           <h1>File Icons</h1>
-          <IconDisplay>
+          <IconDisplay applyColor={color}>
             <div className="story-icon">
               <ficons.FileBookIcon />
               <br />


### PR DESCRIPTION
## What does this do?

- Changed label to tooltip prop in DataTable Action Buttons
- Made more explicit the ability to add custom icon to action buttons

## How does it look?

<img width="235" alt="Screenshot 2023-07-17 at 14 46 50" src="https://github.com/minio/mds/assets/33497058/fce70718-2b4f-4e47-a288-709b6ef3d5e4">
<img width="1944" alt="Screenshot 2023-07-17 at 14 46 44" src="https://github.com/minio/mds/assets/33497058/19512050-0cb0-4eb7-8d0a-f4ce66e40262">
