### PR TITLE
Renamed disableActionFunction & showLoaderFunction in DataTable

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -316,13 +316,30 @@ WithItemActions.args = {
       },
       sendOnlyId: true,
       tooltip: "Edit",
+      isDisabled: true,
     },
     {
       type: "delete",
       onClick: (deleteItem) => {
         console.log("DELETE", deleteItem);
       },
-      tooltip: "Delete",
+      tooltip: "Delete, Disabled if Column 1 is Value1",
+      isDisabled: (value) => value.field1 === "Value1",
+    },
+    {
+      type: "preview",
+      onClick: (deleteItem) => {
+        console.log("PREVIEW", deleteItem);
+      },
+      tooltip: "Preview",
+    },
+    {
+      type: "cloud",
+      onClick: (deleteItem) => {
+        console.log("DELETE", deleteItem);
+      },
+      tooltip: "Delete, Disabled if Column 1 is Value1",
+      showLoader: (value) => value.field1 === "Value1",
     },
   ],
   records: [

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -18,7 +18,6 @@ import React, { FC, Fragment, useState } from "react";
 import { AutoSizer, Column, InfiniteLoader, Table } from "react-virtualized";
 import styled from "styled-components";
 import get from "lodash/get";
-import isPlainObject from "lodash/isPlainObject";
 import isString from "lodash/isString";
 import Checkbox from "../Checkbox/Checkbox";
 import Loader from "../Loader/Loader";
@@ -202,17 +201,12 @@ const DataTableWrapper = styled.div<DataTableWrapperProps>(
       textAlign: "right",
     },
     "& .progress-enabled": {
-      paddingTop: 3,
-      display: "inline-block",
-      margin: "0 10px",
+      display: "inline-flex",
       position: "relative",
-      width: 18,
-      height: 18,
-    },
-    "& .progress-enabled > .MuiCircularProgress-root": {
-      position: "absolute",
-      left: 0,
-      top: 3,
+      alignItems: "center",
+      justifyContent: "center",
+      width: 30,
+      height: 30,
     },
     ...sx,
   }),
@@ -270,9 +264,11 @@ const DataTable: FC<DataTableProps> = ({
 
       let disabled = false;
 
-      if (findView.disableButtonFunction) {
-        if (findView.disableButtonFunction(valueClick)) {
-          disabled = true;
+      if (!!findView.isDisabled) {
+        if (typeof findView.isDisabled === "boolean") {
+          disabled = findView.isDisabled;
+        } else {
+          disabled = findView.isDisabled(rowItem);
         }
       }
 

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -37,9 +37,8 @@ export interface ItemActions {
   tooltip?: string;
   type: PredefinedActionTypes | React.ReactNode;
   sendOnlyId?: boolean;
-  disableButtonFunction?: (itemValue: any) => boolean;
-  showLoaderFunction?: (itemValue: any) => boolean;
-
+  isDisabled?: boolean | ((itemValue: any) => boolean);
+  showLoader?: boolean | ((itemValue: any) => boolean);
   onClick?(valueToSend: any): any;
 }
 

--- a/src/components/DataTable/DataTable.utils.tsx
+++ b/src/components/DataTable/DataTable.utils.tsx
@@ -19,10 +19,10 @@ import get from "lodash/get";
 import isString from "lodash/isString";
 import { Column } from "react-virtualized";
 import {
+  actionsTypes,
   IColumns,
   ItemActions,
   PredefinedActionTypes,
-  actionsTypes,
 } from "./DataTable.types";
 import ArrowDropUpIcon from "../Icons/ArrowDropUp";
 import ArrowDropDownIcon from "../Icons/ArrowDropDown";
@@ -182,19 +182,21 @@ export const elementActions = (
       return null;
     }
 
-    const vlSend =
-      typeof valueToSend === "string" ? valueToSend : valueToSend[idField];
-
     let disabled = false;
 
-    if (action.disableButtonFunction) {
-      if (action.disableButtonFunction(vlSend)) {
-        disabled = true;
+    if (!!action.isDisabled) {
+      if (typeof action.isDisabled === "boolean") {
+        disabled = action.isDisabled;
+      } else {
+        disabled = action.isDisabled(valueToSend);
       }
     }
 
-    if (action.showLoaderFunction) {
-      if (action.showLoaderFunction(vlSend)) {
+    if (!!action.showLoader) {
+      if (
+        (typeof action.showLoader === "boolean" && action.showLoader) ||
+        action.showLoader(valueToSend)
+      ) {
         return (
           <div className={"progress-enabled"}>
             <Loader


### PR DESCRIPTION
## What does this do?

- Renamed disableActionFunction & showLoaderFunction in favor of isDisabled & showLoder.
- Changed to always send the full object to the validation function.
- Added support to send a function or a boolean to these functions

## How does it look?

<img width="1381" alt="Screenshot 2023-07-19 at 15 28 46" src="https://github.com/minio/mds/assets/33497058/76abd6c0-8920-40b8-b6ef-43c4652ea21e">
