### PR TITLE
Added SizeChart component to mds

### DIFF
--- a/src/components/SizeChart/SizeChart.stories.tsx
+++ b/src/components/SizeChart/SizeChart.stories.tsx
@@ -1,0 +1,80 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Fragment } from "react";
+import { Meta, Story } from "@storybook/react";
+
+import SizeChart from "./SizeChart";
+import { SizeChartProps } from "./SizeChart.types";
+
+import StoryThemeProvider from "../../utils/StoryThemeProvider";
+import { Button, GlobalStyles } from "../index";
+import TestIcon from "../../utils/TestIcon";
+
+export default {
+  title: "MDS/Data/SizeChart",
+  component: SizeChart,
+  argTypes: {},
+} as Meta<typeof SizeChart>;
+
+const Template: Story<SizeChartProps> = (args) => (
+  <StoryThemeProvider>
+    <GlobalStyles />
+    <SizeChart {...args} />
+  </StoryThemeProvider>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  usedBytes: 45000,
+  totalBytes: 100000,
+};
+
+export const WarningSpace = Template.bind({});
+WarningSpace.args = {
+  usedBytes: 85000,
+  totalBytes: 100000,
+};
+
+export const DangerSpace = Template.bind({});
+DangerSpace.args = {
+  usedBytes: 95000,
+  totalBytes: 100000,
+};
+
+export const WithLabel = Template.bind({});
+WithLabel.args = {
+  usedBytes: 95000,
+  totalBytes: 100000,
+  label: true,
+};
+
+export const WithChartLabel = Template.bind({});
+WithChartLabel.args = {
+  usedBytes: 9504400,
+  totalBytes: 103840000,
+  label: true,
+  chartLabel: "Reported Usage",
+};
+
+export const CustomSize = Template.bind({});
+CustomSize.args = {
+  usedBytes: 95000,
+  totalBytes: 100000,
+  label: true,
+  width: 50,
+  height: 50,
+};

--- a/src/components/SizeChart/SizeChart.tsx
+++ b/src/components/SizeChart/SizeChart.tsx
@@ -1,0 +1,163 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { FC, SVGProps, useEffect, useRef } from "react";
+import styled from "styled-components";
+import get from "lodash/get";
+import { SizeChartConstructProps, SizeChartProps } from "./SizeChart.types";
+import { lightColors } from "../../global/themes";
+import { calculateBytes } from "../../global/utils";
+
+const SizeChartBase = styled.svg<SVGProps<any> & SizeChartConstructProps>(
+  ({ theme, usedBytes, totalBytes, chartLabel, sx }) => {
+    const percUsed = (usedBytes * 100) / totalBytes;
+
+    let color = get(theme, "signalColors.main", lightColors.mainBlue);
+
+    if (percUsed >= 90) {
+      color = get(theme, "signalColors.danger", lightColors.mainRed);
+    } else if (percUsed >= 80) {
+      color = get(theme, "signalColors.warning", lightColors.mainOrange);
+    }
+
+    return {
+      "& .usedSpace": {
+        stroke: color,
+      },
+      "& .availableSpace": {
+        stroke: get(theme, "signalColors.disabled", lightColors.disabledGrey),
+      },
+      "& .chartText": {
+        fill: "#000",
+        transform: "translateY(0.25em)",
+      },
+      "& .chartNumber": {
+        fontSize: "0.3em",
+        lineHeight: 1,
+        textAnchor: "middle",
+        transform:
+          chartLabel !== "" ? "translateY(-0.50em)" : "translateY(-0.25em)",
+        fontWeight: "bold",
+        fill: get(theme, "fontColor", lightColors.defaultFontColor),
+      },
+      "& .chartLabel": {
+        fontSize: "0.2em",
+        textAnchor: "middle",
+        transform: "translateY(0.7em)",
+        whiteSpace: "normal",
+        fontWeight: "bold",
+        fill: get(theme, "mutedText", lightColors.mutedText),
+      },
+      ...sx,
+    };
+  },
+);
+
+const SizeChart: FC<SizeChartProps> = ({
+  width = "150",
+  height = "150",
+  usedBytes,
+  totalBytes,
+  label,
+  chartLabel = "",
+  sx,
+}) => {
+  const val1D = useRef<SVGCircleElement>(null);
+  const val2D = useRef<SVGCircleElement>(null);
+
+  useEffect(() => {
+    setTimeout(function () {
+      if (val1D?.current) {
+        val1D.current.style.transition =
+          "stroke-dasharray 0.5s ease-in-out, stroke-dashoffset 0.5s ease-in-out";
+        val1D.current.style.strokeDasharray = "100 0";
+      }
+    }, 20);
+  }, []);
+
+  useEffect(() => {
+    const val1 = usedBytes;
+    const val2 = totalBytes - usedBytes;
+
+    const total = val1 + val2;
+
+    const per1 = (val1 / total) * 100;
+    const per2 = (val2 / total) * 100;
+    const offset = 25;
+
+    if (val1D?.current && val2D?.current) {
+      val1D.current.style.transition =
+        "stroke-dasharray 0.5s ease-in-out, stroke-dashoffset 0.5s ease-in-out";
+      val1D.current.style.strokeDasharray = per1 + " " + (100 - per1);
+      val1D.current.style.strokeDashoffset = `${offset}`;
+
+      val2D.current.style.transition =
+        "stroke-dasharray 0.5s ease-in-out, stroke-dashoffset 0.5s ease-in-out";
+      val2D.current.style.strokeDasharray = per2 + " " + (100 - per2);
+      val2D.current.style.strokeDashoffset = `${100 - per1 + offset}`;
+    }
+  }, [usedBytes, totalBytes]);
+
+  const usedSizeUnits = calculateBytes(usedBytes);
+
+  return (
+    <SizeChartBase
+      width={width}
+      height={height}
+      viewBox="0 0 42 42"
+      usedBytes={usedBytes}
+      totalBytes={totalBytes}
+      sx={sx}
+      chartLabel={chartLabel}
+    >
+      <circle
+        className={"usedSpace"}
+        cx="21"
+        cy="21"
+        r="15.91549430918954"
+        fill="transparent"
+        strokeWidth="3"
+        strokeDasharray="100 0"
+        strokeDashoffset="25"
+        ref={val1D}
+      />
+      <circle
+        className={"availableSpace"}
+        cx="21"
+        cy="21"
+        r="15.91549430918954"
+        fill="transparent"
+        stroke="#ff0000"
+        strokeWidth="3"
+        strokeDasharray="100 0"
+        strokeDashoffset="25"
+        ref={val2D}
+      />
+      {label && (
+        <g className="chartText">
+          <text x="50%" y="50%" className="chartNumber">
+            {usedSizeUnits.total}&nbsp;{usedSizeUnits.unit}
+          </text>
+          <text x="50%" y="50%" className="chartLabel">
+            {chartLabel}
+          </text>
+        </g>
+      )}
+    </SizeChartBase>
+  );
+};
+
+export default SizeChart;

--- a/src/components/SizeChart/SizeChart.types.ts
+++ b/src/components/SizeChart/SizeChart.types.ts
@@ -1,0 +1,32 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { CSSObject } from "styled-components";
+
+export interface SizeChartMain {
+  label: boolean;
+  width?: string;
+  height?: string;
+}
+
+export interface SizeChartConstructProps {
+  usedBytes: number;
+  totalBytes: number;
+  chartLabel?: string;
+  sx?: CSSObject;
+}
+
+export type SizeChartProps = SizeChartMain & SizeChartConstructProps;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*Basics*/
-export { breakPoints } from "../global/utils";
+export { breakPoints, calculateBytes } from "../global/utils";
 
 export { default as ThemeHandler } from "./ThemeHandler/ThemeHandler";
 export { default as GlobalStyles } from "./GlobalStyles/GlobalStyles";
@@ -61,6 +61,7 @@ export { default as ActionLink } from "./ActionLink/ActionLink";
 export { default as ValuePair } from "./ValuePair/ValuePair";
 export { default as ProgressBar } from "./ProgressBar/ProgressBar";
 export { default as FileSelector } from "./FileSelector/FileSelector";
+export { default as SizeChart } from "./SizeChart/SizeChart";
 
 /*Icons*/
 export * from "./Icons";
@@ -105,3 +106,4 @@ export * from "./ActionLink/ActionLink.types";
 export * from "./ValuePair/ValuePair.types";
 export * from "./ProgressBar/ProgressBar.types";
 export * from "./FileSelector/FileSelector.types";
+export * from "./SizeChart/SizeChart.types";

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -318,3 +318,8 @@ export interface SelectorType {
   extraValue?: any;
   disabled?: boolean;
 }
+
+export interface IBytesCalc {
+  total: number;
+  unit: string;
+}

--- a/src/global/utils.ts
+++ b/src/global/utils.ts
@@ -14,7 +14,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { IBytesCalc } from "./global.types";
+
 export const breakPoints = { xs: 0, sm: 576, md: 768, lg: 992, xl: 1200 };
+export const units = [
+  "B",
+  "KiB",
+  "MiB",
+  "GiB",
+  "TiB",
+  "PiB",
+  "EiB",
+  "ZiB",
+  "YiB",
+];
 
 export const fractionToPerc = (fraction: "auto" | number | boolean) => {
   if (fraction === "auto" || (typeof fraction === "boolean" && fraction)) {
@@ -36,4 +49,40 @@ export const fractionToPerc = (fraction: "auto" | number | boolean) => {
   const percCalculate = (fr * 100) / 12;
 
   return `${percCalculate}%`;
+};
+
+export const calculateBytes = (
+  x: string | number,
+  showDecimals = false,
+  roundFloor = true,
+): IBytesCalc => {
+  let bytes;
+
+  if (typeof x === "string") {
+    bytes = parseInt(x, 10);
+  } else {
+    bytes = x;
+  }
+
+  if (bytes === 0) {
+    return { total: 0, unit: units[0] };
+  }
+
+  // Gi : GiB
+  const k = 1024;
+
+  // Get unit for measure
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  const fractionDigits = showDecimals ? 1 : 0;
+
+  const bytesUnit = bytes / Math.pow(k, i);
+
+  const roundedUnit = roundFloor ? Math.floor(bytesUnit) : bytesUnit;
+
+  // Get Unit parsed
+  const unitParsed = parseFloat(roundedUnit.toFixed(fractionDigits));
+  const finalUnit = units[i];
+
+  return { total: unitParsed, unit: finalUnit };
 };


### PR DESCRIPTION
## What does this do?

Added SizeChart component to mds

## How does it look?

<img width="792" alt="Screenshot 2023-08-28 at 19 04 30" src="https://github.com/minio/mds/assets/33497058/4bb5e9ec-2714-44ec-909a-fe175c931e29">
<img width="987" alt="Screenshot 2023-08-28 at 19 04 25" src="https://github.com/minio/mds/assets/33497058/edab040c-508b-4876-a1c3-5b4937bbcf4a">
<img width="690" alt="Screenshot 2023-08-28 at 19 04 08" src="https://github.com/minio/mds/assets/33497058/280b38ae-6ebf-4542-b2c1-6931defee427">
<img width="757" alt="Screenshot 2023-08-28 at 19 04 04" src="https://github.com/minio/mds/assets/33497058/983eb477-0912-472d-a7c2-43dd7fe449e3">
<img width="740" alt="Screenshot 2023-08-28 at 19 03 28" src="https://github.com/minio/mds/assets/33497058/942534b9-cf8a-4790-bd98-0763d28a816d">
<img width="704" alt="Screenshot 2023-08-28 at 19 03 22" src="https://github.com/minio/mds/assets/33497058/dccd6ab1-b0c1-4b3b-8b55-00968dbc991b">
<img width="796" alt="Screenshot 2023-08-28 at 19 03 17" src="https://github.com/minio/mds/assets/33497058/4efeea10-89c2-45ab-8f85-1ead2485f319">
<img width="990" alt="Screenshot 2023-08-28 at 19 03 12" src="https://github.com/minio/mds/assets/33497058/856ec495-7b67-471b-8573-de233045ed93">
