### PR TITLE
Changed Accordion Title type to accept Components

### DIFF
--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -21,7 +21,7 @@ export interface AccordionProps {
   expanded: boolean;
   onTitleClick: () => void;
   id: string;
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   disabled?: boolean;
   sx?: CSSObject;


### PR DESCRIPTION
## What does this do?

Changed Accordion title type to accept react components