### PR TITLE
Tag Improvements

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -29,13 +29,27 @@ export default {
   argTypes: {},
 } as Meta<typeof Tag>;
 
-const Template: Story<TagProps> = ({ label, id, onDelete, sx, color }) => {
+const Template: Story<TagProps> = ({
+  label,
+  id,
+  onDelete,
+  sx,
+  color,
+  square,
+}) => {
   return (
     <StoryThemeProvider>
       <GlobalStyles />
-      <Tag label={label} color={color} id={id} sx={sx} />
+      <Tag label={label} color={color} id={id} sx={sx} square={square} />
       &nbsp;
-      <Tag label={label} color={color} id={id} onDelete={onDelete} sx={sx}>
+      <Tag
+        label={label}
+        color={color}
+        id={id}
+        onDelete={onDelete}
+        sx={sx}
+        square={square}
+      >
         {" "}
         with on Delete
       </Tag>
@@ -47,12 +61,20 @@ const Template: Story<TagProps> = ({ label, id, onDelete, sx, color }) => {
         onDelete={onDelete}
         sx={sx}
         variant={"outlined"}
+        square={square}
       >
         {" "}
         Outlined
       </Tag>
       &nbsp;
-      <Tag label={label} color={color} id={id} sx={sx} icon={<AddIcon />}>
+      <Tag
+        label={label}
+        color={color}
+        id={id}
+        sx={sx}
+        icon={<AddIcon />}
+        square={square}
+      >
         {" "}
         With an Icon
       </Tag>
@@ -64,6 +86,7 @@ const Template: Story<TagProps> = ({ label, id, onDelete, sx, color }) => {
         sx={sx}
         variant={"outlined"}
         icon={<AddIcon />}
+        square={square}
       >
         {" "}
         Outlined With an Icon
@@ -112,6 +135,16 @@ Warn.args = {
   },
 };
 
+export const Grey = Template.bind({});
+Grey.args = {
+  label: "A Tag",
+  id: "tag-test",
+  color: "grey",
+  onDelete: () => {
+    alert("Clicked Delete Button!");
+  },
+};
+
 export const Ok = Template.bind({});
 Ok.args = {
   label: "A Tag",
@@ -120,6 +153,17 @@ Ok.args = {
   onDelete: () => {
     alert("Clicked Delete Button!");
   },
+};
+
+export const Square = Template.bind({});
+Square.args = {
+  label: "A Tag",
+  id: "tag-test",
+  color: "default",
+  onDelete: () => {
+    alert("Clicked Delete Button!");
+  },
+  square: true,
 };
 
 export const CustomStyles = Template.bind({});

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -22,7 +22,7 @@ import AlertCloseIcon from "../Icons/AlertCloseIcon";
 import { lightColors } from "../../global/themes";
 
 const TagBase = styled.span<TagConstructProps>(
-  ({ theme, color, variant, sx }) => {
+  ({ theme, color, variant, square, sx }) => {
     return {
       position: "relative",
       margin: 0,
@@ -30,7 +30,7 @@ const TagBase = styled.span<TagConstructProps>(
       appearance: "none",
       maxWidth: "100%",
       fontFamily: "'Inter', sans-serif",
-      fontSize: 14,
+      fontSize: 13,
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
@@ -43,7 +43,7 @@ const TagBase = styled.span<TagConstructProps>(
         variant === "regular"
           ? get(theme, `tag.${color}.background`, lightColors.mainBlue)
           : "transparent",
-      borderRadius: 16,
+      borderRadius: square ? 3 : 16,
       whiteSpace: "nowrap",
       cursor: "default",
       outline: 0,
@@ -104,10 +104,18 @@ const Tag: FC<TagProps & React.HTMLAttributes<HTMLSpanElement>> = ({
   label,
   variant = "regular",
   icon,
+  square = false,
   ...props
 }) => {
   return (
-    <TagBase id={id} color={color} sx={sx} variant={variant} {...props}>
+    <TagBase
+      id={id}
+      color={color}
+      sx={sx}
+      variant={variant}
+      square={square}
+      {...props}
+    >
       {icon}
       <span>
         {label}

--- a/src/components/Tag/Tag.types.ts
+++ b/src/components/Tag/Tag.types.ts
@@ -25,9 +25,10 @@ export interface TagMainProps {
 }
 
 export interface TagConstructProps {
-  color?: "default" | "secondary" | "warn" | "alert" | "ok";
+  color?: "default" | "secondary" | "warn" | "alert" | "ok" | "grey";
   sx?: CSSObject;
   variant?: "regular" | "outlined";
+  square?: boolean;
 }
 
 export type TagProps = TagMainProps & TagConstructProps;

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -267,6 +267,7 @@ export interface TagThemeProps {
   warn: TagVariantProps;
   alert: TagVariantProps;
   ok: TagVariantProps;
+  grey: TagVariantProps;
 }
 
 interface SnackBarColorElements {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -560,6 +560,11 @@ export const lightTheme: ThemeDefinitionProps = {
       label: lightColors.defaultFontColor,
       deleteColor: lightColors.defaultFontColor,
     },
+    grey: {
+      background: lightColors.actionDisabledGrey,
+      label: lightColors.defaultFontColor,
+      deleteColor: lightColors.defaultFontColor,
+    },
   },
   snackbar: {
     error: {
@@ -958,6 +963,11 @@ export const darkTheme: ThemeDefinitionProps = {
       background: darkColors.mainGreen,
       label: darkColors.dark,
       deleteColor: darkColors.dark,
+    },
+    grey: {
+      background: darkColors.disabledBGGrey,
+      label: darkColors.mainWhite,
+      deleteColor: darkColors.mainWhite,
     },
   },
   snackbar: {


### PR DESCRIPTION
## What does this do?

- Added Square tag variant
- Added grey colored tag

## How does it look?

<img width="1227" alt="Screenshot 2023-10-04 at 3 59 32 p m" src="https://github.com/minio/mds/assets/33497058/a006c2e7-67a0-488c-873f-be43041af043">
<img width="1160" alt="Screenshot 2023-10-04 at 3 58 53 p m" src="https://github.com/minio/mds/assets/33497058/3fbbf1f4-55dc-4a17-9ef3-a7e9e6286082">
<img width="1287" alt="Screenshot 2023-10-04 at 3 58 47 p m" src="https://github.com/minio/mds/assets/33497058/50f4f0a5-17f2-4abd-b156-e4a53a5fbfeb">
