### PR TITLE
Added Informative Message Component

### DIFF
--- a/src/components/InformativeMessage/InformativeMessage.stories.tsx
+++ b/src/components/InformativeMessage/InformativeMessage.stories.tsx
@@ -1,0 +1,67 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+
+import InformativeMessage from "./InformativeMessage";
+import { InformativeMessageProps } from "./InformativeMessage.types";
+
+import StoryThemeProvider from "../../utils/StoryThemeProvider";
+import { GlobalStyles } from "../index";
+
+export default {
+  title: "MDS/Information/InformativeMessage",
+  component: InformativeMessage,
+  argTypes: {},
+} as Meta<typeof InformativeMessage>;
+
+const Template: Story<InformativeMessageProps> = ({ ...props }) => {
+  return (
+    <StoryThemeProvider>
+      <GlobalStyles />
+      <InformativeMessage {...props} />
+    </StoryThemeProvider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  variant: "default",
+  title: "This is the title for a message",
+  message: "This is the content for an informative message",
+};
+
+export const Success = Template.bind({});
+Success.args = {
+  variant: "success",
+  title: "This is the title for a message",
+  message: "This is the content for a success message",
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  variant: "warning",
+  title: "This is the title for a message",
+  message: "This is the content for an warning message",
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  variant: "error",
+  title: "This is the title for a message",
+  message: "This is the content for an error message",
+};

--- a/src/components/InformativeMessage/InformativeMessage.tsx
+++ b/src/components/InformativeMessage/InformativeMessage.tsx
@@ -1,0 +1,81 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { FC } from "react";
+import styled from "styled-components";
+import {
+  ConstructProps,
+  InformativeMessageProps,
+} from "./InformativeMessage.types";
+import get from "lodash/get";
+import { lightColors } from "../../global/themes";
+
+const InformativeMessageMain = styled.div<ConstructProps>(
+  ({ theme, sx, variant }) => ({
+    backgroundColor: get(
+      theme,
+      `informativeMessage.${variant}.backgroundColor`,
+      lightColors.mainBlue,
+    ),
+    border: `1px solid ${get(
+      theme,
+      `informativeMessage.${variant}.borderColor`,
+      lightColors.mainBlue,
+    )}`,
+    borderRadius: 3,
+    padding: "10px 20px",
+    "& .labelHeadline": {
+      color: get(
+        theme,
+        `informativeMessage.${variant}.textColor`,
+        lightColors.white,
+      ),
+      fontSize: 14,
+      fontWeight: "bold",
+      marginBottom: 10,
+    },
+    "& .messageText": {
+      color: get(
+        theme,
+        `informativeMessage.${variant}.textColor`,
+        lightColors.white,
+      ),
+      fontSize: 14,
+    },
+    ...sx,
+  }),
+);
+
+const InformativeMessage: FC<InformativeMessageProps> = ({
+  title,
+  message,
+  sx,
+  variant = "default",
+  ...props
+}) => {
+  return (
+    <InformativeMessageMain
+      sx={sx}
+      variant={variant}
+      className={`informative-message`}
+    >
+      <div className={"labelHeadline"}>{title}</div>
+      <div className={"messageText"}>{message}</div>
+    </InformativeMessageMain>
+  );
+};
+
+export default InformativeMessage;

--- a/src/components/InformativeMessage/InformativeMessage.types.ts
+++ b/src/components/InformativeMessage/InformativeMessage.types.ts
@@ -1,0 +1,30 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from "react";
+import { CSSObject } from "styled-components";
+
+export interface InformativeMessageMain {
+  title: React.ReactNode;
+  message: React.ReactNode;
+}
+
+export interface ConstructProps {
+  variant?: "default" | "success" | "warning" | "error";
+  sx?: CSSObject;
+}
+
+export type InformativeMessageProps = InformativeMessageMain & ConstructProps;

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -282,6 +282,19 @@ export interface SnackBarThemeProps {
   error: SnackBarColorElements;
 }
 
+export interface InformativeColorElements {
+  backgroundColor: string;
+  borderColor: string;
+  textColor: string;
+}
+
+export interface InformativeMessageProps {
+  default: InformativeColorElements;
+  success: InformativeColorElements;
+  warning: InformativeColorElements;
+  error: InformativeColorElements;
+}
+
 export interface ThemeDefinitionProps {
   bgColor: string;
   fontColor: string;
@@ -323,6 +336,7 @@ export interface ThemeDefinitionProps {
   codeEditor?: CodeEditorThemeProps;
   tag?: TagThemeProps;
   snackbar?: SnackBarThemeProps;
+  informativeMessage?: InformativeMessageProps;
 }
 
 export interface SelectorType {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -584,6 +584,28 @@ export const lightTheme: ThemeDefinitionProps = {
       labelColor: lightColors.defaultFontColor,
     },
   },
+  informativeMessage: {
+    error: {
+      backgroundColor: lightColors.mainRed,
+      borderColor: lightColors.mainRed,
+      textColor: lightColors.white,
+    },
+    default: {
+      backgroundColor: lightColors.mainBlue,
+      borderColor: lightColors.mainBlue,
+      textColor: lightColors.white,
+    },
+    success: {
+      backgroundColor: lightColors.mainGreen,
+      borderColor: lightColors.mainGreen,
+      textColor: lightColors.white,
+    },
+    warning: {
+      backgroundColor: lightColors.mainOrange,
+      borderColor: lightColors.mainOrange,
+      textColor: lightColors.defaultFontColor,
+    },
+  },
 };
 
 export const darkTheme: ThemeDefinitionProps = {
@@ -986,6 +1008,28 @@ export const darkTheme: ThemeDefinitionProps = {
     warning: {
       backgroundColor: darkColors.mainOrange,
       labelColor: darkColors.dark,
+    },
+  },
+  informativeMessage: {
+    error: {
+      backgroundColor: darkColors.mainRed,
+      borderColor: darkColors.mainRed,
+      textColor: darkColors.mainWhite,
+    },
+    default: {
+      backgroundColor: darkColors.mainGrey,
+      borderColor: darkColors.mainGrey,
+      textColor: darkColors.dark,
+    },
+    success: {
+      backgroundColor: darkColors.mainGreen,
+      borderColor: darkColors.mainGreen,
+      textColor: darkColors.dark,
+    },
+    warning: {
+      backgroundColor: darkColors.mainOrange,
+      borderColor: darkColors.mainOrange,
+      textColor: darkColors.dark,
     },
   },
 };


### PR DESCRIPTION
## What does this do?

Added informative Message Component to mds

## How does it look?

<img width="1603" alt="Screenshot 2023-10-12 at 3 14 21 p m" src="https://github.com/minio/mds/assets/33497058/ae807959-7afe-4b07-8017-f4318e538d8d">
<img width="1600" alt="Screenshot 2023-10-12 at 3 14 15 p m" src="https://github.com/minio/mds/assets/33497058/c4b37510-dedc-44c0-8397-bb0754ebdb7f">
<img width="1598" alt="Screenshot 2023-10-12 at 3 14 09 p m" src="https://github.com/minio/mds/assets/33497058/2424474f-9874-449e-95b0-b640b9da89ff">
<img width="1599" alt="Screenshot 2023-10-12 at 3 14 04 p m" src="https://github.com/minio/mds/assets/33497058/405aa901-4ad9-41fc-afdc-5ead773d9fc1">
<img width="1601" alt="Screenshot 2023-10-12 at 3 13 58 p m" src="https://github.com/minio/mds/assets/33497058/d69d75c8-60b3-49f4-bd04-03e9fde7b087">
<img width="1598" alt="Screenshot 2023-10-12 at 3 13 51 p m" src="https://github.com/minio/mds/assets/33497058/b48708a2-d7d0-4152-8c78-c3442699099b">
<img width="1597" alt="Screenshot 2023-10-12 at 3 13 47 p m" src="https://github.com/minio/mds/assets/33497058/8c8b6f6b-37ee-4916-8832-62a0bf536804">
<img width="1591" alt="Screenshot 2023-10-12 at 3 13 42 p m" src="https://github.com/minio/mds/assets/33497058/0721b3a7-637b-4076-9c3d-22133a74ca93">
