### PR TITLE
Added extra validation to useArrowKeys hook

### DIFF
--- a/src/global/hooks.ts
+++ b/src/global/hooks.ts
@@ -59,7 +59,7 @@ export const useArrowKeys = (
 ) => {
   const handleArrow = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key.startsWith("Arrow")) {
+      if (event.key?.startsWith("Arrow")) {
         event.preventDefault();
         event.stopPropagation();
         handleAction(event.key);


### PR DESCRIPTION
## What does this do?

Added an extra validation to the `useArrowKeys` hook, where in specific corner cases the validation could fail