### PR TITLE
Updated Breadcrumbs component with new requirements

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbButton.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbButton.tsx
@@ -1,0 +1,128 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { FC, Fragment } from "react";
+import { BreadcrumbsOptionProps } from "./Breadcrumbs.types";
+import styled from "styled-components";
+import { ButtonProps, ConstructProps } from "../Button/Button.types";
+import get from "lodash/get";
+import { themeColors } from "../../global/themeColors";
+
+const CustomBreadcrumb = styled.button<
+  ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement> & ConstructProps
+>(
+  ({
+    theme,
+    fullWidth,
+    variant,
+    iconLocation,
+    icon,
+    label,
+    collapseOnSmall,
+    parentChildren,
+    compact,
+    sx,
+  }) => ({
+    cursor: "pointer",
+    display: "inline-block" as const,
+    boxSizing: "border-box",
+    border: 0,
+    backgroundColor: "transparent",
+    padding: "2px 4px",
+    color: get(
+      theme,
+      "elementsColor",
+      themeColors["Color/Neutral/Text/colorTextDescription"].lightMode,
+    ),
+    fontSize: 12,
+    fontStyle: "normal",
+    fontWeight: 400,
+    lineHeight: "16px",
+    letterSpacing: "0.5px",
+    textOverflow: "ellipsis" as const,
+    overflow: "hidden" as const,
+    whiteSpace: "nowrap" as const,
+    borderRadius: 2,
+    height: 20,
+    "&.current": {
+      cursor: "default",
+      color: get(
+        theme,
+        "selectedColor",
+        themeColors["Color/Neutral/Text/colorTextHeading"].lightMode,
+      ),
+      fontWeight: 600,
+    },
+    "&:not(.current):hover": {
+      backgroundColor: get(
+        theme,
+        "hoverBG",
+        themeColors["Color/Brand/Neutral/colorPrimaryBg"].lightMode,
+      ),
+      color: get(
+        theme,
+        "hoverColor",
+        themeColors["Color/Brand/Neutral/colorPrimaryText"].lightMode,
+      ),
+      textDecoration: "underline",
+    },
+  }),
+);
+
+const BreadcrumbButton: FC<
+  BreadcrumbsOptionProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({
+  label,
+  icon,
+  iconLocation = "end",
+  onClick,
+  disabled,
+  children,
+  className,
+  current,
+  ...props
+}) => {
+  let iconToPlace: React.ReactNode = null;
+
+  if (icon) {
+    iconToPlace = <span className={"buttonIcon"}>{icon}</span>;
+  }
+
+  return (
+    <CustomBreadcrumb
+      onClick={onClick}
+      disabled={disabled || false}
+      iconLocation={iconLocation || "end"}
+      label={label || ""}
+      icon={iconToPlace}
+      parentChildren={children || null}
+      className={`breadcrumbElement ${className || ""} ${current ? "current" : ""}`}
+      {...props}
+    >
+      <Fragment>
+        {icon && iconLocation === "start" && iconToPlace}
+        <span className={"button-label"}>
+          {children}
+          {children && label ? " " : ""}
+          {label}
+        </span>
+        {icon && iconLocation === "end" && iconToPlace}
+      </Fragment>
+    </CustomBreadcrumb>
+  );
+};
+
+export default BreadcrumbButton;

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -14,16 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { Fragment } from "react";
+import React from "react";
 import { Meta, Story } from "@storybook/react";
 
 import Breadcrumbs from "./Breadcrumbs";
-import { BreadcrumbsProps } from "./Breadcrumbs.types";
+import { BreadcrumbsOption, BreadcrumbsProps } from "./Breadcrumbs.types";
 
 import StoryThemeProvider from "../../utils/StoryThemeProvider";
 import { GlobalStyles } from "../index";
-import Button from "../Button/Button";
-import CopyIcon from "../Icons/CopyIcon";
 
 export default {
   title: "MDS/Layout/Breadcrumbs",
@@ -34,57 +32,42 @@ export default {
 const Template: Story<BreadcrumbsProps> = (args) => (
   <StoryThemeProvider>
     <GlobalStyles />
-    <Breadcrumbs
-      additionalOptions={
-        <Fragment>
-          <Button
-            id={"copy-path"}
-            icon={
-              <CopyIcon
-                style={{
-                  width: "12px",
-                  height: "12px",
-                  fill: "#969FA8",
-                  marginTop: -1,
-                }}
-              />
-            }
-            variant={"regular"}
-            onClick={() => {
-              alert("Copy test");
-            }}
-            style={{
-              width: "28px",
-              height: "28px",
-              color: "#969FA8",
-              border: "#969FA8 1px solid",
-              marginRight: 5,
-            }}
-          />
-        </Fragment>
-      }
-      goBackFunction={() => {
-        alert("Go back!");
-      }}
-    >
-      <a href="#">First Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Second Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Third Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Fourth Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Fifth Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Sixth Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Seventh Link</a>
-      <span className={"slashSpacingStyle"}>/</span>
-      <a href="#">Eighth Link</a>
-    </Breadcrumbs>
+    <Breadcrumbs {...args} />
   </StoryThemeProvider>
 );
 
+const brOptions: BreadcrumbsOption[] = [
+  { label: "Home", to: "/lol" },
+  { label: "Level 1", to: "/lol" },
+  { label: "Level 2", to: "/lol" },
+  { label: "Level 3", to: "/lol" },
+  { label: "Level 4", to: "/lol" },
+  { label: "Level 5", to: "/lol" },
+  { label: "Level 6", to: "/lol" },
+];
+
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  options: brOptions,
+};
+
+export const WithBackButton = Template.bind({});
+WithBackButton.args = {
+  options: brOptions,
+  goBackFunction: () => {
+    alert("Go back!");
+  },
+};
+
+export const DisplayLastNItemsOnly = Template.bind({});
+DisplayLastNItemsOnly.args = {
+  options: brOptions,
+  displayLastItems: 2,
+};
+
+export const MarkCurrentItem = Template.bind({});
+MarkCurrentItem.args = {
+  options: brOptions,
+  markCurrentItem: true,
+  displayLastItems: 2,
+};

--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -14,16 +14,38 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from "react";
+import React, { MouseEventHandler, ReactNode } from "react";
 import { CSSObject } from "styled-components";
 
 export interface BreadcrumbsProps {
   sx?: CSSObject;
-  children: React.ReactNode;
-  additionalOptions?: React.ReactNode;
-  goBackFunction: () => void;
+  options: BreadcrumbsOption[];
+  goBackFunction?: () => void;
+  displayLastItems?: false | number;
+  onClickOption?: (to?: string) => void;
+  children?: React.ReactNode;
+  markCurrentItem?: boolean;
+}
+
+export interface BreadcrumbsOption {
+  label: string;
+  to?: string;
+  onClick?: (to?: string) => void;
 }
 
 export interface BreadcrumbsContainerProps {
+  sx?: CSSObject;
+}
+
+export interface BreadcrumbsOptionProps {
+  id: string;
+  name?: string;
+  label?: string;
+  icon?: ReactNode;
+  iconLocation?: "start" | "end";
+  disabled?: boolean;
+  current?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  children?: ReactNode | string;
   sx?: CSSObject;
 }

--- a/src/components/ExpandMenu/ExpandMenu.tsx
+++ b/src/components/ExpandMenu/ExpandMenu.tsx
@@ -32,6 +32,7 @@ const ExpandMenu: FC<
   label,
   children,
   disabled,
+  compact = false,
 }) => {
   const [expandedMenu, setExpandedMenu] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = React.useState<
@@ -49,6 +50,7 @@ const ExpandMenu: FC<
         sx={sx}
         label={label}
         disabled={disabled}
+        compact={compact}
         onClick={(e) => {
           setExpandedMenu(!expandedMenu);
           setAnchorEl(e.currentTarget);

--- a/src/components/ExpandMenu/ExpandMenu.types.ts
+++ b/src/components/ExpandMenu/ExpandMenu.types.ts
@@ -27,6 +27,7 @@ export interface ExpandMenuProps {
   iconLocation?: "start" | "end";
   children?: ReactNode | string;
   dropMenuPosition?: "start" | "end";
+  compact?: boolean;
   sx?: CSSObject;
 }
 

--- a/src/components/Icons/ExpandOptionsIcon.tsx
+++ b/src/components/Icons/ExpandOptionsIcon.tsx
@@ -1,0 +1,51 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as React from "react";
+import { SVGProps } from "react";
+
+const ExpandOptionsIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={`min-icon`}
+    fill={"currentcolor"}
+    viewBox="0 0 256 256"
+    {...props}
+  >
+    <g>
+      <g>
+        <path
+          d="M128,156.65c-15.81,0-28.67-12.85-28.67-28.64s12.86-28.66,28.67-28.66,28.66,12.86,28.66,28.66-12.86,28.64-28.66,28.64ZM128,127.3c-.39,0-.71.32-.71.71l.71-.71Z"
+          strokeWidth={"0px"}
+        />
+      </g>
+      <g>
+        <path
+          d="M225.84,156.65c-15.81,0-28.67-12.85-28.67-28.64s12.86-28.66,28.67-28.66,28.67,12.86,28.67,28.66-12.86,28.64-28.67,28.64ZM225.84,127.3c-.39,0-.7.32-.7.71l.7-.71Z"
+          strokeWidth={"0px"}
+        />
+      </g>
+      <g>
+        <path
+          d="M30.15,156.65c-15.8,0-28.66-12.85-28.66-28.64s12.86-28.66,28.66-28.66,28.67,12.86,28.67,28.66-12.86,28.64-28.67,28.64ZM30.15,127.3c-.38,0-.7.32-.7.71l.7-.71Z"
+          strokeWidth={"0px"}
+        />
+      </g>
+    </g>
+  </svg>
+);
+
+export default ExpandOptionsIcon;

--- a/src/components/Icons/Icons.stories.tsx
+++ b/src/components/Icons/Icons.stories.tsx
@@ -597,6 +597,12 @@ const Template: Story = (args) => {
             </div>
 
             <div className="story-icon">
+              <cicons.ExpandOptionsIcon />
+              <br />
+              ExpandOptionsIcon
+            </div>
+
+            <div className="story-icon">
               <cicons.ExtraFeaturesIcon />
               <br />
               ExtraFeaturesIcon

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -254,3 +254,4 @@ export { default as QueryEditorIcon } from "./QueryEditorIcon";
 export { default as ResourcesIcon } from "./ResourcesIcon";
 export { default as SettingsInMenuIcon } from "./SettingsInMenuIcon";
 export { default as SystemIcon } from "./SystemIcon";
+export { default as ExpandOptionsIcon } from "./ExpandOptionsIcon";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,7 @@ export { default as PageLayout } from "./PageLayout/PageLayout";
 export { default as MainContainer } from "./MainContainer/MainContainer";
 export { default as InputBox } from "./InputBox/InputBox";
 export { default as Breadcrumbs } from "./Breadcrumbs/Breadcrumbs";
+export { default as BreadcrumbButton } from "./Breadcrumbs/BreadcrumbButton";
 export { default as ActionsList } from "./ActionsList/ActionsList";
 export { default as SimpleHeader } from "./SimpleHeader/SimpleHeader";
 export { default as ScreenTitle } from "./ScreenTitle/ScreenTitle";

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -116,17 +116,11 @@ export interface InputBoxThemeProps {
   disabledPlaceholder: string;
 }
 
-export interface BreadcrumbsBackStyle {
-  border: string;
-  backgroundColor: string;
-}
-
 export interface BreadcrumbsThemeProps {
-  border: string;
-  backgroundColor: string;
-  linksColor: string;
-  backButton: BreadcrumbsBackStyle;
-  textColor: string;
+  elementsColor: string;
+  selectedColor: string;
+  hoverColor: string;
+  hoverBG: string;
 }
 
 export interface ActionsListThemeProps {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -515,14 +515,11 @@ export const lightTheme: ThemeDefinitionProps = {
     disabledText: lightV2.mutedText,
   },
   breadcrumbs: {
-    border: lightColors.borderColor,
-    linksColor: lightColors.commonLinkColor,
-    textColor: lightColors.breadcrumbsText,
-    backgroundColor: lightColors.breadcrumbsBackground,
-    backButton: {
-      border: lightColors.breadcrumbsBackBorder,
-      backgroundColor: lightColors.white,
-    },
+    elementsColor:
+      themeColors["Color/Neutral/Text/colorTextDescription"].lightMode,
+    selectedColor: themeColors["Color/Neutral/Text/colorTextHeading"].lightMode,
+    hoverBG: themeColors["Color/Brand/Neutral/colorPrimaryBg"].lightMode,
+    hoverColor: themeColors["Color/Brand/Neutral/colorPrimaryText"].lightMode,
   },
   actionsList: {
     containerBorderColor: lightColors.actionsListBorder,
@@ -1028,14 +1025,11 @@ export const darkTheme: ThemeDefinitionProps = {
     disabledText: darkColors.disabledBGGrey,
   },
   breadcrumbs: {
-    border: darkColors.borderColor,
-    linksColor: darkColors.mainGrey,
-    textColor: darkColors.mainGrey,
-    backgroundColor: darkColors.sectionOneBG,
-    backButton: {
-      border: darkColors.borderColor,
-      backgroundColor: darkColors.sectionOneBG,
-    },
+    elementsColor:
+      themeColors["Color/Neutral/Text/colorTextDescription"].darkMode,
+    selectedColor: themeColors["Color/Neutral/Text/colorTextHeading"].darkMode,
+    hoverBG: themeColors["Color/Brand/Neutral/colorPrimaryBg"].darkMode,
+    hoverColor: themeColors["Color/Brand/Neutral/colorPrimaryText"].darkMode,
   },
   actionsList: {
     containerBorderColor: darkColors.bulletColor,

--- a/src/utils/GlobalUtils.ts
+++ b/src/utils/GlobalUtils.ts
@@ -33,6 +33,7 @@ export const expandMenuOptionStyles = (theme: any) => {
     fontWeight: 400,
     height: 28,
     boxShadow: "none",
+    textDecoration: "none",
     "&:hover:not(:disabled)": {
       backgroundColor: get(
         theme,


### PR DESCRIPTION
## What does this do?
Updated Breadcrumbs with new requirements

**BREAKING CHANGES**
Breadcrumbs now require an object with options to work

> Note: Back icon will be updated as well as icons package.

## How does it look?

<img width="939" alt="Screenshot 2024-04-09 at 11 18 06 p m" src="https://github.com/minio/mds/assets/33497058/d7b43579-8875-4093-adf2-c5ab97a30bb2">
<img width="1144" alt="Screenshot 2024-04-09 at 11 07 38 p m" src="https://github.com/minio/mds/assets/33497058/3768c835-b380-4e04-83cf-fda39da7c519">
<img width="951" alt="Screenshot 2024-04-09 at 11 07 33 p m" src="https://github.com/minio/mds/assets/33497058/4dc2ebef-2ddb-40e3-8ed2-83ad98c2b704">
<img width="1069" alt="Screenshot 2024-04-09 at 11 07 29 p m" src="https://github.com/minio/mds/assets/33497058/bd1ab6a6-d820-4a45-94d5-464b3700bfac">
<img width="1041" alt="Screenshot 2024-04-09 at 11 07 24 p m" src="https://github.com/minio/mds/assets/33497058/e8db5ff8-e76a-4d27-9525-5bded049c2aa">
