### PR TITLE
Fixed breadcrumbs issue

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -71,3 +71,9 @@ MarkCurrentItem.args = {
   markCurrentItem: true,
   displayLastItems: 2,
 };
+
+export const LimitAsListSize = Template.bind({});
+LimitAsListSize.args = {
+  options: brOptions,
+  displayLastItems: 6,
+};

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -102,7 +102,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
 }) => {
   const hasCollapsedOpts =
     typeof displayLastItems === "number" &&
-    options.length > displayLastItems + 1 &&
+    options.length - 1 > displayLastItems &&
     options.length > 0;
 
   let collapsedOptions = null;
@@ -122,7 +122,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
   };
 
   // Collapsed options
-  if (hasCollapsedOpts) {
+  if (hasCollapsedOpts && options.length > displayLastItems - 1) {
     const colOpts = options.slice(1, displayLastItems * -1);
 
     collapsedOptions = (
@@ -150,7 +150,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
     );
   }
 
-  const itSlide = displayLastItems
+  const itSlide = hasCollapsedOpts
     ? options.slice(displayLastItems * -1)
     : options;
 


### PR DESCRIPTION
## What does this do?

Fixed breadcrumbs issue where displayLastItems breaks in some cases


## How does it look?

<img width="483" alt="Screenshot 2024-04-12 at 9 53 36 p m" src="https://github.com/minio/mds/assets/33497058/1ba3a9fd-4649-453b-b972-b61c67638061">
<img width="778" alt="Screenshot 2024-04-12 at 9 53 14 p m" src="https://github.com/minio/mds/assets/33497058/fbdc7bdc-89b7-4ba8-8eb0-805e3fae08d7">
