### PR TITLE
Centered items in ScreenTitle when no Subtitle & Title Options are present

### DIFF
--- a/src/components/ScreenTitle/ScreenTitle.stories.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.stories.tsx
@@ -119,6 +119,23 @@ CustomSubElement.args = {
   ),
 };
 
+export const NoSubItems = Template.bind({});
+NoSubItems.args = {
+  title: "Object Title",
+  actions: (
+    <Fragment>
+      <ButtonGroup>
+        <Button id={"testButton1"}>Button1</Button>
+        <Button id={"testButton3"}>Button3</Button>
+      </ButtonGroup>
+      <Button id={"testButton2"} variant={"callAction"} compact>
+        Button2
+      </Button>
+    </Fragment>
+  ),
+  icon: <TestIcon />,
+};
+
 export const CustomStyles = Template.bind({});
 CustomStyles.args = {
   title: "Object Title",

--- a/src/components/ScreenTitle/ScreenTitle.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.tsx
@@ -28,7 +28,7 @@ import BoxedIcon from "../BoxedIcon/BoxedIcon";
 import { themeColors } from "../../global/themeColors";
 
 const ScreenTitleContainer = styled.div<ScreenTitleContainerProps>(
-  ({ theme, sx }) => ({
+  ({ theme, sx, subTitle, titleOptions }) => ({
     boxSizing: "border-box" as const,
     display: "flex",
     flexDirection: "row",
@@ -36,7 +36,8 @@ const ScreenTitleContainer = styled.div<ScreenTitleContainerProps>(
     width: "100%",
     "& .stContainer": {
       display: "flex",
-      alignItems: "flex-start" as const,
+      alignItems:
+        !subTitle && !titleOptions ? "center" : ("flex-start" as const),
       justifyContent: "space-between",
       padding: 8,
       width: "100%",
@@ -53,12 +54,12 @@ const ScreenTitleContainer = styled.div<ScreenTitleContainerProps>(
       fontSize: 14,
     },
     "& .titleColumn": {
-      height: "auto",
+      height: !subTitle && !titleOptions ? "60px" : ("auto" as const),
       justifyContent: "center",
       display: "flex",
       flexFlow: "column",
       alignItems: "flex-start",
-      gap: 4,
+      gap: 4 as const,
       "& .titleElement": {
         fontSize: 24,
         fontWeight: 600,
@@ -146,21 +147,31 @@ const ScreenTitle: FC<ScreenTitleProps & HTMLAttributes<HTMLDivElement>> = ({
   ...restProps
 }) => {
   return (
-    <ScreenTitleContainer className={"screen-title"} sx={sx} {...restProps}>
+    <ScreenTitleContainer
+      className={"screen-title"}
+      sx={sx}
+      subTitle={subTitle}
+      titleOptions={titleOptions}
+      {...restProps}
+    >
       <Box className={"stContainer"}>
         <Box className={"leftItems"}>
           {icon ? <BoxedIcon>{icon}</BoxedIcon> : null}
           <Box className={"titleColumn"}>
             <Box className={"titleElement"}>{title}</Box>
-            <span className={"headerBarSubheader"}>{subTitle}</span>
-            <Box className={"options"}>
-              {titleOptions?.map((optionItem) => (
-                <Box className={"optionElement"}>
-                  <Box className={"title"}>{optionItem.title}</Box>
-                  <Box className={"value"}>{optionItem.value}</Box>
-                </Box>
-              ))}
-            </Box>
+            {subTitle && (
+              <span className={"headerBarSubheader"}>{subTitle}</span>
+            )}
+            {titleOptions && (
+              <Box className={"options"}>
+                {titleOptions?.map((optionItem) => (
+                  <Box className={"optionElement"}>
+                    <Box className={"title"}>{optionItem.title}</Box>
+                    <Box className={"value"}>{optionItem.value}</Box>
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Box>
         </Box>
         <Box className={"rightItems"}>{actions}</Box>

--- a/src/components/ScreenTitle/ScreenTitle.types.ts
+++ b/src/components/ScreenTitle/ScreenTitle.types.ts
@@ -27,6 +27,8 @@ export interface ScreenTitleProps {
 }
 
 export interface ScreenTitleContainerProps {
+  subTitle?: React.ReactNode;
+  titleOptions?: ScreenTitleOptions[];
   sx?: CSSObject;
   bottomBorder?: boolean;
 }

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -238,7 +238,7 @@ export const lightV2 = {
 export const lightTheme: ThemeDefinitionProps = {
   bgColor: lightV2.mainBackgroundColor,
   fontColor: lightV2.fontColor,
-  borderColor: lightV2.colorBorderSubtle,
+  borderColor: themeColors["Color/Neutral/Border/colorBorderMinimal"].lightMode,
   bulletColor: lightColors.bulletColor,
   logoColor: lightColors.mainRed,
   logoLabelColor: lightColors.logoLabel,


### PR DESCRIPTION
## What does this do?

Centered items in ScreenTitle when no Subtitle & Title Options are present

## How does it look?

<img width="1466" alt="Screenshot 2024-04-15 at 5 52 48 p m" src="https://github.com/minio/mds/assets/33497058/8a37deac-c83d-4c53-8154-aa581ad69312">
<img width="1473" alt="Screenshot 2024-04-15 at 5 52 39 p m" src="https://github.com/minio/mds/assets/33497058/4f824456-3c7e-4472-a611-f2be35609731">
<img width="1465" alt="Screenshot 2024-04-15 at 5 52 31 p m" src="https://github.com/minio/mds/assets/33497058/9da57cb6-f544-42f6-8503-8aba2f79ef36">
<img width="1467" alt="Screenshot 2024-04-15 at 5 52 24 p m" src="https://github.com/minio/mds/assets/33497058/2555826d-c193-4b6e-b2e1-4ac4eacce374">
