### PR TITLE
Adjust back button size in Breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -157,14 +157,17 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
   return (
     <BoxParent className={"breadcrumbs-bar"} sx={sx}>
       {goBackFunction && (
-        <ButtonGroup displayLabels={false}>
-          <Button
-            id={"back-button"}
-            icon={<BackCaretIcon />}
-            onClick={goBackFunction}
-            iconLocation={"start"}
-          />
-        </ButtonGroup>
+        <Button
+          id={"back-button"}
+          icon={<BackCaretIcon />}
+          onClick={goBackFunction}
+          iconLocation={"start"}
+          compact
+          sx={{
+            width: 28,
+            height: 28,
+          }}
+        />
       )}
       <Box className={"breadcrumbsList"}>
         {hasCollapsedOpts ? (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -181,6 +181,7 @@ const Button: FC<
   children,
   compact = false,
   className,
+  sx,
   ...props
 }) => {
   let iconToPlace: React.ReactNode = null;
@@ -202,6 +203,7 @@ const Button: FC<
       parentChildren={children || null}
       className={`${className || ""} button-${variant}`}
       compact={compact}
+      sx={sx}
       {...props}
     >
       <Fragment>


### PR DESCRIPTION
## What does this do?

Adjust back button size in Breadcrumbs

## How does it look?
<img width="677" alt="Screenshot 2024-04-15 at 7 58 57 p m" src="https://github.com/minio/mds/assets/33497058/e84d8398-d1a9-49b4-91ee-8a5363f9d4ab">


