### PR TITLE
Updated sx property to accept a function to handle inline theming

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,7 +21,7 @@ module.exports = {
       },
     },
     "@storybook/addon-webpack5-compiler-babel",
-    "@chromatic-com/storybook"
+    "@chromatic-com/storybook",
   ],
   framework: {
     name: "@storybook/react-webpack5",

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -26,11 +26,12 @@ import { lightColors } from "../../global/themes";
 import { ExpandCaret } from "../Icons";
 import CollapseCaret from "../Icons/CollapseCaret";
 import Box from "../Box/Box";
+import { overridePropsParse } from "../../global/utils";
 
 const AccordionContainer = styled.div<AccordionMainProps>(({ theme, sx }) => ({
   border: `1px solid ${get(theme, "borderColor", lightColors.borderColor)}`,
   borderRadius: 2,
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const AccordionTitleBar = styled.div<HTMLAttributes<HTMLDivElement>>(

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ReactNode } from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface AccordionProps {
   expanded: boolean;
@@ -24,11 +24,11 @@ export interface AccordionProps {
   title: ReactNode;
   children: ReactNode;
   disabled?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface AccordionMainProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface AccordionContentProps {

--- a/src/components/ActionLink/ActionLink.tsx
+++ b/src/components/ActionLink/ActionLink.tsx
@@ -18,8 +18,9 @@ import React, { FC, Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
 import { ActionLinkProps, BaseActionLinkProps } from "./ActionLink.types";
-import { lightColors, lightV2 } from "../../global/themes";
+import { lightV2 } from "../../global/themes";
 import Loader from "../Loader/Loader";
+import { overridePropsParse } from "../../global/utils";
 
 const ActionLinkBase = styled.button<BaseActionLinkProps>(({ theme, sx }) => ({
   cursor: "pointer",
@@ -37,7 +38,7 @@ const ActionLinkBase = styled.button<BaseActionLinkProps>(({ theme, sx }) => ({
   "&:hover": {
     textDecoration: "underline",
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const ActionLink: FC<

--- a/src/components/ActionLink/ActionLink.types.ts
+++ b/src/components/ActionLink/ActionLink.types.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface CommonActionLinkProps {
   isLoading?: boolean;
@@ -22,7 +22,7 @@ export interface CommonActionLinkProps {
 }
 
 export interface BaseActionLinkProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type ActionLinkProps = CommonActionLinkProps & BaseActionLinkProps;

--- a/src/components/ActionsList/ActionsList.tsx
+++ b/src/components/ActionsList/ActionsList.tsx
@@ -20,6 +20,7 @@ import styled from "styled-components";
 import Tooltip from "../Tooltip/Tooltip";
 import ObjectActionButton from "./ObjectActionButton";
 import get from "lodash/get";
+import { overridePropsParse } from "../../global/utils";
 
 const ActionsListPanel = styled.div<
   HTMLAttributes<HTMLDivElement> & ActionsListPanelProps
@@ -70,7 +71,7 @@ const ActionsListPanel = styled.div<
       },
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const ActionsList: FC<ActionsListProps> = ({ sx, items, title }) => {

--- a/src/components/ActionsList/ActionsList.types.ts
+++ b/src/components/ActionsList/ActionsList.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ActionItem {
   action: () => void;
@@ -26,13 +26,13 @@ export interface ActionItem {
 }
 
 export interface ActionsListProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   items: ActionItem[];
   title: React.ReactNode;
 }
 
 export interface ActionsListPanelProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ActionButtonProps

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -26,6 +26,7 @@ import Box from "../Box/Box";
 import CollapseCaret from "../Icons/CollapseCaret";
 import ExpandCaret from "../Icons/ExpandCaret";
 import DropdownSelector from "../DropdownSelector/DropdownSelector";
+import { overridePropsParse } from "../../global/utils";
 
 const AutocompleteBase = styled.input(({ theme }) => {
   let borderColor = get(theme, "inputBox.border", "#E2E2E2");
@@ -129,7 +130,7 @@ const InputContainer = styled.div<InputContainerProps>(
         height: 16,
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Autocomplete/Autocomplete.types.ts
+++ b/src/components/Autocomplete/Autocomplete.types.ts
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
-import { SelectorType } from "../../global/global.types";
+import { OverrideTheme, SelectorType } from "../../global/global.types";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
 
 export interface AutocompleteProps {
@@ -32,7 +31,7 @@ export interface AutocompleteProps {
   noLabelMinWidth?: boolean;
   placeholder?: string;
   onChange: (newValue: string, extraValue?: any) => void;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }

--- a/src/components/BackLink/BackLink.tsx
+++ b/src/components/BackLink/BackLink.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { BackLinkProps } from "./BackLink.types";
 import BackSettingsIcon from "../Icons/BackSettingsIcon";
+import { overridePropsParse } from "../../global/utils";
 
 const BackLinkBasic = styled.button<BackLinkProps>(({ theme, sx }) => ({
   display: "flex",
@@ -58,7 +59,7 @@ const BackLinkBasic = styled.button<BackLinkProps>(({ theme, sx }) => ({
       color: get(theme, "backLink.arrow", "#081C42"),
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const BackLink: FC<BackLinkProps> = ({ label, sx, ...props }) => {

--- a/src/components/BackLink/BackLink.types.ts
+++ b/src/components/BackLink/BackLink.types.ts
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSProperties } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface BackLinkProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  sx?: CSSProperties;
+  sx?: OverrideTheme;
   label?: string;
 }

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import { BadgeConstruct, BadgeProps } from "./Badge.types";
 import { lightColors } from "../../global/themes";
 import get from "lodash/get";
+import { overridePropsParse } from "../../global/utils";
 
 const BadgeParent = styled.span<
   HTMLAttributes<HTMLDivElement> & BadgeConstruct
@@ -66,7 +67,7 @@ const BadgeParent = styled.span<
           horizontalPosition === "right" ? "" : "-"
         }50%, ${verticalPosition === "bottom" ? "" : "-"}50%)`,
       },
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface BadgeMain {
   invisible?: boolean;
@@ -26,7 +26,7 @@ export interface BadgeMain {
 export interface BadgeConstruct {
   horizontalPosition?: "left" | "right";
   verticalPosition?: "bottom" | "top";
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   color?: "default" | "secondary" | "warn" | "alert" | "ok" | "grey";
   shape?: "circular" | "rectangular";
   dotOnly?: boolean;

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -21,7 +21,7 @@ import Box from "./Box";
 import { BoxProps } from "./Box.types";
 
 import StoryThemeProvider from "../../utils/StoryThemeProvider";
-import { GlobalStyles } from "../index";
+import { GlobalStyles, ThemeDefinitionProps } from "../index";
 
 export default {
   title: "MDS/Layout/Box",
@@ -76,4 +76,15 @@ BoxWithCustomStyles.args = {
     backgroundColor: "#460",
     borderColor: "#f9a",
   },
+};
+
+export const BoxWithFunctionCustomStyles = Template.bind({});
+BoxWithFunctionCustomStyles.args = {
+  withBorders: true,
+  sx: (theme: ThemeDefinitionProps) => ({
+    backgroundColor: theme.signalColors?.danger || "#000",
+    color: theme.bgColor,
+    borderRadius: 5,
+    padding: 8,
+  }),
 };

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { BoxProps } from "./Box.types";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const BoxParent = styled.div<BoxProps & React.HTMLAttributes<HTMLDivElement>>(
   ({ theme, sx, withBorders, customBorderPadding, useBackground }) => {
@@ -39,7 +40,7 @@ const BoxParent = styled.div<BoxProps & React.HTMLAttributes<HTMLDivElement>>(
         ? get(theme, "boxBackground", "#FBFAFA")
         : "transparent",
       ...extraBorders,
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/Box/Box.types.ts
+++ b/src/components/Box/Box.types.ts
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface BoxProps extends React.HTMLAttributes<HTMLDivElement> {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   children?: React.ReactNode;
   withBorders?: boolean;
   customBorderPadding?: number | string;

--- a/src/components/BoxedIcon/BoxedIcon.tsx
+++ b/src/components/BoxedIcon/BoxedIcon.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { themeColors } from "../../global/themeColors";
 import { IBoxedIconProps } from "./BoxedIcon.types";
+import { overridePropsParse } from "../../global/utils";
 
 const IconContainer = styled.div<IBoxedIconProps>(({ theme, sx }) => ({
   display: "flex",
@@ -47,7 +48,7 @@ const IconContainer = styled.div<IBoxedIconProps>(({ theme, sx }) => ({
     minWidth: 24,
     minHeight: 24,
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const BoxedIcon: FC<IBoxedIconProps> = ({ sx, children }) => {

--- a/src/components/BoxedIcon/BoxedIcon.types.ts
+++ b/src/components/BoxedIcon/BoxedIcon.types.ts
@@ -15,9 +15,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface IBoxedIconProps {
   children: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -31,6 +31,7 @@ import Button from "../Button/Button";
 import get from "lodash/get";
 import { themeColors } from "../../global/themeColors";
 import ExpandOptionsIcon from "../Icons/ExpandOptionsIcon";
+import { overridePropsParse } from "../../global/utils";
 
 const BoxParent = styled.div<BreadcrumbsContainerProps>(({ theme, sx }) => {
   return {
@@ -87,7 +88,7 @@ const BoxParent = styled.div<BreadcrumbsContainerProps>(({ theme, sx }) => {
     "& .slashSpacingStyle": {
       margin: "0 5px",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   };
 });
 

--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { MouseEventHandler, ReactNode } from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface BreadcrumbsProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   options: BreadcrumbsOption[];
   goBackFunction?: () => void;
   displayLastItems?: false | number;
@@ -34,7 +34,7 @@ export interface BreadcrumbsOption {
 }
 
 export interface BreadcrumbsContainerProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface BreadcrumbsOptionProps {
@@ -47,5 +47,5 @@ export interface BreadcrumbsOptionProps {
   current?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   children?: ReactNode | string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -36,6 +36,16 @@ const Template: Story<ButtonProps> = (args) => (
     <Button {...args} onClick={() => alert("You clicked me!")} />
     <br />
     <Button {...args}>With Children</Button>
+    <br />
+    <Button
+      id={"asdf"}
+      sx={(theme) => ({
+        backgroundColor: theme.colors["Color/Base/Royal/9"],
+        color: theme.colors["Color/Base/Royal/0"],
+      })}
+    >
+      Func
+    </Button>
   </StoryThemeProvider>
 );
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ import React, { FC, Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
 import { ButtonProps, ConstructProps } from "./Button.types";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 
 const CustomButton = styled.button<
   ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement> & ConstructProps
@@ -163,7 +163,7 @@ const CustomButton = styled.button<
         },
       },
       ...smallScreenStyles,
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { MouseEventHandler, ReactNode } from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ButtonProps {
   id: string;
@@ -30,7 +30,7 @@ export interface ButtonProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
   children?: ReactNode | string;
   compact?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ConstructProps {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { ButtonGroupProps } from "./ButtonGroup.types";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const ActionsBarMain = styled.div<ButtonGroupProps>(
   ({ theme, sx, displayLabels }) => ({
@@ -128,7 +129,7 @@ const ActionsBarMain = styled.div<ButtonGroupProps>(
         },
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSProperties } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   displayLabels?: boolean;
-  sx?: CSSProperties;
+  sx?: OverrideTheme;
 }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -23,6 +23,7 @@ import { InputLabelProps } from "../InputLabel/InputLabel.types";
 import FieldContainer from "../../global/FieldContainer";
 import Tooltip from "../Tooltip/Tooltip";
 import HelpIcon from "../Icons/HelpIcon";
+import { overridePropsParse } from "../../global/utils";
 
 const CheckboxItem = styled.label<InputLabelProps>(({ sx, theme }) => ({
   "& input": {
@@ -61,7 +62,7 @@ const CheckboxItem = styled.label<InputLabelProps>(({ sx, theme }) => ({
       },
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const Checkbox: FC<

--- a/src/components/Checkbox/Checkbox.types.ts
+++ b/src/components/Checkbox/Checkbox.types.ts
@@ -15,14 +15,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { HTMLAttributes } from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
   label?: string;
   tooltip?: string;
   overrideLabelClasses?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -24,6 +24,7 @@ import Box from "../Box/Box";
 import InputLabel from "../InputLabel/InputLabel";
 import { CodeEditorBaseProps, CodeEditorProps } from "./CodeEditor.types";
 import { lightV2, lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const CodeEditorBase = styled.div<CodeEditorBaseProps>(
   ({ theme, editorHeight, sx }) => ({
@@ -230,7 +231,7 @@ const CodeEditorBase = styled.div<CodeEditorBaseProps>(
         },
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/CodeEditor/CodeEditor.types.ts
+++ b/src/components/CodeEditor/CodeEditor.types.ts
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface CodeEditorProps {
   value: string;
@@ -27,13 +27,13 @@ export interface CodeEditorProps {
   onChange: (value: string) => any;
   className?: string;
   helpTools?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }
 
 export interface CodeEditorBaseProps {
   editorHeight: string | number;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   className?: string;
 }

--- a/src/components/CommentBox/CommentBox.tsx
+++ b/src/components/CommentBox/CommentBox.tsx
@@ -27,6 +27,7 @@ import Tooltip from "../Tooltip/Tooltip";
 import InputLabel from "../InputLabel/InputLabel";
 import Box from "../Box/Box";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const TextAreaBase = styled.textarea<CommentBoxProps & ExtraCommentProps>(
   ({ theme, error, originType }) => {
@@ -102,7 +103,7 @@ const BoxContainer = styled.div<CommentContainerProps>(
     "& .inputLabel": {
       marginBottom: error ? 18 : 0,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/CommentBox/CommentBox.types.ts
+++ b/src/components/CommentBox/CommentBox.types.ts
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface CommentBoxProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -24,7 +24,7 @@ export interface CommentBoxProps
   fullWidth?: boolean;
   label?: string;
   tooltip?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   index?: number;
   noLabelMinWidth?: boolean;
   required?: boolean;
@@ -36,7 +36,7 @@ export interface CommentBoxProps
 
 export interface CommentContainerProps {
   children?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   error?: boolean;
   startIcon?: React.ReactNode;
   className?: string;

--- a/src/components/DataTable/ColumnsSelector.tsx
+++ b/src/components/DataTable/ColumnsSelector.tsx
@@ -28,6 +28,7 @@ import { lightColors } from "../../global/themes";
 import Checkbox from "../Checkbox/Checkbox";
 import Box from "../Box/Box";
 import SelectorContainer from "../../global/SelectorContainer";
+import { overridePropsParse } from "../../global/utils";
 
 const SelectorBox = styled.div<ColumnSelectorConstructProps>(
   ({ theme, sx }) => ({
@@ -64,7 +65,7 @@ const SelectorBox = styled.div<ColumnSelectorConstructProps>(
       maxHeight: 250,
       overflowY: "auto",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -46,6 +46,7 @@ import Box from "../Box/Box";
 import Button from "../Button/Button";
 import ColumnsSelector from "./ColumnsSelector";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const DataTableWrapper = styled.div<DataTableWrapperProps>(
   ({ theme, customPaperHeight, disabled, noBackground, sx, rowHeight }) => ({
@@ -214,7 +215,7 @@ const DataTableWrapper = styled.div<DataTableWrapperProps>(
       width: 30,
       height: 30,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { HTMLAttributes } from "react";
-import { CSSObject } from "styled-components";
 import { SortDirectionType } from "react-virtualized";
+import { OverrideTheme } from "../../global/global.types";
 
 export const actionsTypes = [
   "view",
@@ -102,7 +102,7 @@ export interface DataTableProps {
     index: number;
   }) => "deleted" | "" | React.CSSProperties;
   parentClassName?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   rowHeight?: number;
   sortEnabled?: boolean | string[] | ISortConfig;
   sortCallBack?: (info: ITableSortInfo) => void;
@@ -112,7 +112,7 @@ export interface DataTableWrapperProps extends HTMLAttributes<HTMLDivElement> {
   disabled?: boolean;
   customPaperHeight?: string | number;
   noBackground?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   rowHeight: number;
 }
 
@@ -133,10 +133,10 @@ export interface ColumnSelectorProps {
   onSelect: (column: string) => void;
   columns: IColumns[];
   selectedOptionIDs: string[];
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   anchorEl?: (EventTarget & HTMLElement) | null;
 }
 
 export interface ColumnSelectorConstructProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/DateTimeInput/DateTimeInput.tsx
+++ b/src/components/DateTimeInput/DateTimeInput.tsx
@@ -29,6 +29,7 @@ import { InputContainerProps } from "../InputBox/InputBox.types";
 import DateTimeSelector from "./DateTimeSelector";
 import { useEscapeKey } from "../../global/hooks";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const InputBase = styled.input(({ theme }) => {
   let borderColor = get(theme, "inputBox.border", lightColors.borderColor);
@@ -213,7 +214,7 @@ const InputContainer = styled.div<InputContainerProps>(
     "& .inputLabel": {
       marginBottom: error ? 18 : 0,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/DateTimeInput/DateTimeInput.types.ts
+++ b/src/components/DateTimeInput/DateTimeInput.types.ts
@@ -16,8 +16,9 @@
 
 import React from "react";
 import { DateTime } from "luxon";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
+import { CSSObject } from "styled-components";
 
 export interface DateTimeInputMain {
   pickerStartComponent?: React.ReactNode;
@@ -31,12 +32,12 @@ export interface DateTimeInputMain {
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
   noLabelMinWidth?: boolean;
-  pickerSx?: CSSObject;
+  pickerSx?: OverrideTheme;
 }
 
 export interface DateTimeConstruct {
   id: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   mode?: "all" | "date";
   value: DateTime | null;
   onChange: (value: DateTime | null) => void;
@@ -69,7 +70,8 @@ export interface DateSelectorProps {
 export interface StylesOverrideProps {
   isPortal: boolean;
   mode: "all" | "date";
-  sx?: CSSObject;
+  coords: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type DateTimeInputProps = DateTimeInputMain &

--- a/src/components/DateTimeInput/DateTimeSelector.tsx
+++ b/src/components/DateTimeInput/DateTimeSelector.tsx
@@ -31,6 +31,7 @@ import { lightV2 } from "../../global/themes";
 import { DateTime } from "luxon";
 import SelectorContainer from "../../global/SelectorContainer";
 import debounce from "lodash/debounce";
+import { overridePropsParse } from "../../global/utils";
 
 const globalWidth = 315;
 
@@ -59,7 +60,7 @@ const OptionChangeButton = styled.button(({ theme }) => ({
 }));
 
 const DateTimeContainer = styled.div<StylesOverrideProps>(
-  ({ theme, sx, isPortal, mode }) => ({
+  ({ theme, sx, isPortal, mode, coords }) => ({
     position: isPortal ? "absolute" : ("relative" as const),
     border: `1px solid ${get(theme, "borderColor", lightV2.borderColor)}`,
     backgroundColor: get(theme, "signalColors.clear", lightV2.white),
@@ -73,7 +74,8 @@ const DateTimeContainer = styled.div<StylesOverrideProps>(
       gap: 16,
       marginBottom: 18,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
+    ...coords,
   }),
 );
 
@@ -176,7 +178,8 @@ const DateTimeSelector: FC<DateTimeSelectorProps> = ({
       onClick={(e) => e.stopPropagation()}
       id={`timeSelector-${id}`}
       isPortal={usePortal}
-      sx={{ ...sx, ...coords }}
+      coords={coords || {}}
+      sx={sx}
     >
       {mode === "all" && value && (
         <Box className={"modeBar"}>

--- a/src/components/DropdownSelector/DropdownSelector.tsx
+++ b/src/components/DropdownSelector/DropdownSelector.tsx
@@ -28,6 +28,7 @@ import { useArrowKeys, useEnterKey, useEscapeKey } from "../../global/hooks";
 import SelectorContainer from "../../global/SelectorContainer";
 import Box from "../Box/Box";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const DropdownBlock = styled.div<DropDownBlockProps>(
   ({ theme, sx, useAnchorWidth, forSelectInput }) => ({
@@ -57,7 +58,7 @@ const DropdownBlock = styled.div<DropDownBlockProps>(
       flexDirection: "column",
       width: "100%",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/DropdownSelector/DropdownSelector.types.ts
+++ b/src/components/DropdownSelector/DropdownSelector.types.ts
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import React from "react";
-import { SelectorType } from "../../global/global.types";
-import { CSSObject } from "styled-components";
+import { OverrideTheme, SelectorType } from "../../global/global.types";
 
 export interface DropdownSelectorProps {
   id: string;
@@ -38,7 +37,7 @@ export interface DropdownSelectorProps {
 export interface DropDownBlockProps {
   useAnchorWidth: boolean;
   forSelectInput: boolean;
-  sx: CSSObject;
+  sx: OverrideTheme;
 }
 
 export interface DropdownItemProps {

--- a/src/components/ExpandMenu/ExpandDropdown.tsx
+++ b/src/components/ExpandMenu/ExpandDropdown.tsx
@@ -24,6 +24,7 @@ import SelectorContainer from "../../global/SelectorContainer";
 import { lightV2 } from "../../global/themes";
 import { DropdownMainProps, ExpandDropdownProps } from "./ExpandMenu.types";
 import { expandMenuOptionStyles } from "../../utils/GlobalUtils";
+import { overridePropsParse } from "../../global/utils";
 
 const DropdownBlock = styled.div<DropdownMainProps>(({ theme, sx }) => ({
   position: "absolute",
@@ -55,7 +56,7 @@ const DropdownBlock = styled.div<DropdownMainProps>(({ theme, sx }) => ({
     marginBottom: 4,
   },
   "& button": expandMenuOptionStyles(theme),
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const calcElementPosition = (

--- a/src/components/ExpandMenu/ExpandMenu.types.ts
+++ b/src/components/ExpandMenu/ExpandMenu.types.ts
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { MouseEventHandler, ReactNode } from "react";
-import { CSSObject } from "styled-components";
-import { SelectorType } from "../../global/global.types";
+import React, { ReactNode } from "react";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ExpandMenuProps {
   id: string;
@@ -28,14 +27,14 @@ export interface ExpandMenuProps {
   children?: ReactNode | string;
   dropMenuPosition?: "start" | "end";
   compact?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ExpandMenuOptionProps {
   id: string;
   variant?: "regular" | "secondary";
   icon?: ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   children: ReactNode;
 }
 
@@ -49,7 +48,7 @@ export interface ExpandDropBaseProps {
 }
 
 export interface DropdownMainProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type ExpandDropdownProps = DropdownMainProps & ExpandDropBaseProps;

--- a/src/components/ExpandOptionsButton/ExpandOptionsButton.tsx
+++ b/src/components/ExpandOptionsButton/ExpandOptionsButton.tsx
@@ -24,6 +24,7 @@ import {
 import CollapseCaret from "../Icons/CollapseCaret";
 import ExpandCaret from "../Icons/ExpandCaret";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const ExpandButtonBase = styled.button<ConstructExpandOptionsProps>(
   ({ sx, theme }) => ({
@@ -66,7 +67,7 @@ const ExpandButtonBase = styled.button<ConstructExpandOptionsProps>(
       backgroundColor: "transparent",
       cursor: "not-allowed",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ExpandOptionsButton/ExpandOptionsButton.types.ts
+++ b/src/components/ExpandOptionsButton/ExpandOptionsButton.types.ts
@@ -14,15 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ExpandOptionsButtonProps {
   label: string;
   open: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ConstructExpandOptionsProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/FileSelector/FileSelector.tsx
+++ b/src/components/FileSelector/FileSelector.tsx
@@ -29,6 +29,7 @@ import {
 } from "./FileSelector.types";
 import { fileProcess } from "./FileSelector.utils";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const FileSelectorContainer = styled.div<FileSelectorConstructorProps>(
   ({ theme, error, sx }) => ({
@@ -81,7 +82,7 @@ const FileSelectorContainer = styled.div<FileSelectorConstructorProps>(
       alignItems: "center",
       gap: 12,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/FileSelector/FileSelector.types.ts
+++ b/src/components/FileSelector/FileSelector.types.ts
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface FileSelectorProps {
   label: string;
@@ -36,14 +36,14 @@ export interface FileSelectorProps {
   value: string;
   className?: string;
   noLabelMinWidth?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }
 
 export interface FileSelectorConstructorProps {
   children?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   error?: boolean;
   startIcon?: React.ReactNode;
   className?: string;

--- a/src/components/FormActionsTray/FormActionsTray.tsx
+++ b/src/components/FormActionsTray/FormActionsTray.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import { FormActionsTrayProps } from "./FormActionsTray.types";
 import { lightV2 } from "../../global/themes";
 import { get } from "lodash";
+import { overridePropsParse } from "../../global/utils";
 
 const FormActionsTrayMain = styled.div<FormActionsTrayProps>(
   ({ theme, sx, marginTop, separator }) => ({
@@ -30,7 +31,7 @@ const FormActionsTrayMain = styled.div<FormActionsTrayProps>(
     borderTop: separator
       ? `1px solid ${get(theme, "borderColor", lightV2.colorBorderSubtle)}`
       : "0",
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/FormActionsTray/FormActionsTray.types.ts
+++ b/src/components/FormActionsTray/FormActionsTray.types.ts
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface FormActionsTrayProps
   extends React.HTMLAttributes<HTMLDivElement> {
   marginTop?: number;
   separator?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/FormLayout/FormLayout.tsx
+++ b/src/components/FormLayout/FormLayout.tsx
@@ -16,10 +16,42 @@
 
 import React, { FC } from "react";
 import get from "lodash/get";
+import styled from "styled-components";
 import Box from "../Box/Box";
 import SectionTitle from "../SectionTitle/SectionTitle";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 import { FormLayoutProps } from "./FormLayout.types";
+import { lightV2 } from "../../global/themes";
+
+const FormLayoutContainer = styled.div<FormLayoutProps>(
+  ({ theme, sx, containerPadding, helpBox, withBorders }) => {
+    let extraBorders = {};
+
+    if (withBorders) {
+      extraBorders = {
+        border: `${get(theme, "box.border", lightV2.disabledGrey)} 1px solid`,
+        borderRadius: 16,
+        boxShadow: get(theme, "box.shadow", "none"),
+        backgroundColor: get(theme, "box.backgroundColor", lightV2.white),
+      };
+    }
+
+    return {
+      ...extraBorders,
+      display: "grid",
+      padding: containerPadding ? 25 : 0,
+      gap: 25,
+      gridTemplateColumns: "1fr",
+      "& .inputItem:not(:last-of-type)": {
+        marginBottom: 20,
+      },
+      [`@media (min-width: ${get(breakPoints, "md", 0)}px)`]: {
+        gridTemplateColumns: helpBox ? "2fr 1.2fr" : "1fr",
+      },
+      ...overridePropsParse(sx, theme),
+    };
+  },
+);
 
 const FormLayout: FC<FormLayoutProps> = ({
   children,
@@ -31,21 +63,10 @@ const FormLayout: FC<FormLayoutProps> = ({
   withBorders = true,
 }) => {
   return (
-    <Box
+    <FormLayoutContainer
+      sx={sx}
+      containerPadding={containerPadding}
       withBorders={withBorders}
-      sx={{
-        display: "grid",
-        padding: containerPadding ? 25 : 0,
-        gap: 25,
-        gridTemplateColumns: "1fr",
-        "& .inputItem:not(:last-of-type)": {
-          marginBottom: 20,
-        },
-        [`@media (min-width: ${get(breakPoints, "md", 0)}px)`]: {
-          gridTemplateColumns: helpBox ? "2fr 1.2fr" : "1fr",
-        },
-        ...sx,
-      }}
     >
       <Box>
         {title !== "" && (
@@ -56,7 +77,7 @@ const FormLayout: FC<FormLayoutProps> = ({
         {children}
       </Box>
       {helpBox}
-    </Box>
+    </FormLayoutContainer>
   );
 };
 

--- a/src/components/FormLayout/FormLayout.types.ts
+++ b/src/components/FormLayout/FormLayout.types.ts
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface FormLayoutProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   children?: React.ReactNode;
   title?: string;
   icon?: React.ReactNode;

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -18,7 +18,11 @@ import React, { FC } from "react";
 import styled, { CSSObject } from "styled-components";
 import get from "lodash/get";
 import { GridProps } from "./Grid.types";
-import { breakPoints, fractionToPerc } from "../../global/utils";
+import {
+  breakPoints,
+  fractionToPerc,
+  overridePropsParse,
+} from "../../global/utils";
 
 const CustomDiv = styled.div<GridProps>((props) => {
   let constructProps: CSSObject = {
@@ -83,7 +87,7 @@ const CustomDiv = styled.div<GridProps>((props) => {
     });
   }
 
-  return { ...constructProps, ...props.sx };
+  return { ...constructProps, ...overridePropsParse(props.sx, props.theme) };
 });
 
 const Grid: FC<GridProps> = (props) => {

--- a/src/components/Grid/Grid.types.ts
+++ b/src/components/Grid/Grid.types.ts
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { HTMLAttributes, ReactNode } from "react";
-import { CSSObject, CSSProperties } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 interface GridCommonProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 type ConditionalProps =

--- a/src/components/HelpTip/HelpTip.tsx
+++ b/src/components/HelpTip/HelpTip.tsx
@@ -26,7 +26,6 @@ import styled, { css, keyframes } from "styled-components";
 import { createPortal } from "react-dom";
 import get from "lodash/get";
 import {
-  CommonHelpTipPlacement,
   HelpTipBuild,
   HelpTipConstructProps,
   HelpTipProps,

--- a/src/components/IconButton/IconButton.types.ts
+++ b/src/components/IconButton/IconButton.types.ts
@@ -15,12 +15,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface IconBase {
   label?: string;
   size?: "small" | "medium" | "large" | string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   children: React.ReactNode;
 }
 

--- a/src/components/InformativeMessage/InformativeMessage.tsx
+++ b/src/components/InformativeMessage/InformativeMessage.tsx
@@ -22,6 +22,7 @@ import {
 } from "./InformativeMessage.types";
 import get from "lodash/get";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const InformativeMessageMain = styled.div<InformativeConstructProps>(
   ({ theme, sx, variant }) => ({
@@ -55,7 +56,7 @@ const InformativeMessageMain = styled.div<InformativeConstructProps>(
       ),
       fontSize: 14,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/InformativeMessage/InformativeMessage.types.ts
+++ b/src/components/InformativeMessage/InformativeMessage.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface InformativeMessageMain {
   title: React.ReactNode;
@@ -24,7 +24,7 @@ export interface InformativeMessageMain {
 
 export interface InformativeConstructProps {
   variant?: "default" | "success" | "warning" | "error";
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type InformativeMessageProps = InformativeMessageMain &

--- a/src/components/InputBox/InputBox.tsx
+++ b/src/components/InputBox/InputBox.tsx
@@ -30,6 +30,7 @@ import VisibilityOffIcon from "../Icons/VisibilityOffIcon";
 import VisibilityOnIcon from "../Icons/VisibilityOnIcon";
 import Box from "../Box/Box";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const InputBase = styled.input<InputBoxProps & ExtraInputProps>(
   ({ theme, error, startIcon, overlayIcon, overlayObject, originType }) => {
@@ -125,7 +126,7 @@ const InputContainer = styled.div<InputContainerProps>(
         fill: get(theme, "inputBox.color", "#07193E"),
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/InputBox/InputBox.types.ts
+++ b/src/components/InputBox/InputBox.types.ts
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface InputBoxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -24,7 +24,7 @@ export interface InputBoxProps
   fullWidth?: boolean;
   label?: string;
   tooltip?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   index?: number;
   overlayId?: "index";
   overlayIcon?: React.ReactNode;
@@ -41,7 +41,7 @@ export interface InputBoxProps
 
 export interface InputContainerProps {
   children?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   error?: boolean;
   startIcon?: React.ReactNode;
   className?: string;

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -20,6 +20,7 @@ import get from "lodash/get";
 import { InputLabelProps } from "./InputLabel.types";
 import HelpTip from "../HelpTip/HelpTip";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const CustomLabel = styled.label<InputLabelProps>(({ theme, sx }) => ({
   fontWeight: "normal" as const,
@@ -39,7 +40,7 @@ const CustomLabel = styled.label<InputLabelProps>(({ theme, sx }) => ({
       minWidth: "initial",
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const InputLabel: FC<InputLabelProps> = ({

--- a/src/components/InputLabel/InputLabel.types.ts
+++ b/src/components/InputLabel/InputLabel.types.ts
@@ -15,12 +15,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { HTMLAttributes, ReactNode } from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface InputLabelProps extends HTMLAttributes<HTMLLabelElement> {
   children?: ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   noMinWidth?: boolean;
   htmlFor?: string;
   helpTip?: ReactNode;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -19,6 +19,7 @@ import get from "lodash/get";
 import styled from "styled-components";
 import { lightColors, lightV2 } from "../../global/themes";
 import { LinkProps } from "./Link.types";
+import { overridePropsParse } from "../../global/utils";
 
 const LinkBase = styled.a<LinkProps>(({ theme, sx }) => ({
   cursor: "pointer",
@@ -46,7 +47,7 @@ const LinkBase = styled.a<LinkProps>(({ theme, sx }) => ({
       color: get(theme, "secondaryLinkColor", lightV2.modalCloseColor),
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const Link: FC<LinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({

--- a/src/components/Link/Link.types.ts
+++ b/src/components/Link/Link.types.ts
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface LinkProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -22,7 +22,7 @@ import {
   MainContainerProps,
   ParentBoxProps,
 } from "./MainContainer.types";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 
 const CustomMain = styled.main<CustomMainProps>(({ theme, horizontal }) => {
   return {
@@ -36,7 +36,7 @@ const CustomMain = styled.main<CustomMainProps>(({ theme, horizontal }) => {
 });
 
 const ParentBox = styled.div<ParentBoxProps>(
-  ({ horizontal, mobileModeAuto, sx }) => {
+  ({ horizontal, mobileModeAuto, sx, theme }) => {
     let breakPoint = {};
 
     if (mobileModeAuto) {
@@ -51,7 +51,7 @@ const ParentBox = styled.div<ParentBoxProps>(
       display: "flex",
       flexDirection: !!horizontal ? "column" : "row",
       ...breakPoint,
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/MainContainer/MainContainer.types.ts
+++ b/src/components/MainContainer/MainContainer.types.ts
@@ -15,20 +15,20 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface MainContainerProps {
   menu?: React.ReactElement;
   children: React.ReactElement;
   horizontal?: boolean;
   mobileModeAuto?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ParentBoxProps {
   horizontal?: boolean;
   mobileModeAuto: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface CustomMainProps {

--- a/src/components/Menu/Horizontal/HorizontalMenu.tsx
+++ b/src/components/Menu/Horizontal/HorizontalMenu.tsx
@@ -24,6 +24,7 @@ import LogoutIcon from "../../Icons/LogoutIcon";
 import ApplicationLogo from "../../ApplicationLogo/ApplicationLogo";
 import HorizontalMenuItem from "./HorizontalMenuItem";
 import IconButton from "../../IconButton/IconButton";
+import { overridePropsParse } from "../../../global/utils";
 
 const HorizontalMenuContainer = styled.div<MenuConstructProps>(
   ({ theme, sx }) => {
@@ -84,7 +85,7 @@ const HorizontalMenuContainer = styled.div<MenuConstructProps>(
           height: 0,
         },
       },
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -15,12 +15,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { HTMLAttributes } from "react";
-import { CSSObject } from "styled-components";
 import { ApplicationLogoProps } from "../ApplicationLogo/ApplicationLogo.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface MenuProps {
   options?: MenuItemProps[];
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   applicationLogo: ApplicationLogoProps;
   callPathAction: (path: string) => void;
   horizontal?: boolean;
@@ -58,7 +58,7 @@ export interface MainHeaderProps {
 }
 
 export interface MenuConstructProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface SubItemsBoxProps {

--- a/src/components/Menu/MobileMenu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu/MobileMenu.tsx
@@ -25,6 +25,7 @@ import IconButton from "../../IconButton/IconButton";
 import MobileMenuList from "./MobileMenuList";
 import { createPortal } from "react-dom";
 import { lightColors } from "../../../global/themes";
+import { overridePropsParse } from "../../../global/utils";
 
 const MobileMenuContainer = styled.div<MenuConstructProps>(({ theme, sx }) => {
   return {
@@ -56,7 +57,7 @@ const MobileMenuContainer = styled.div<MenuConstructProps>(({ theme, sx }) => {
         height: 0,
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   };
 });
 

--- a/src/components/Menu/MobileMenu/MobileMenuList.tsx
+++ b/src/components/Menu/MobileMenu/MobileMenuList.tsx
@@ -27,6 +27,7 @@ import MenuSectionHeader from "../Vertical/MenuSectionHeader";
 import MenuItem from "../Vertical/MenuItem";
 import LogoutIcon from "../../Icons/LogoutIcon";
 import AlertCloseIcon from "../../Icons/AlertCloseIcon";
+import { overridePropsParse } from "../../../global/utils";
 
 const MobileMenuContainer = styled.div<MenuConstructProps>(({ theme, sx }) => {
   return {
@@ -83,7 +84,7 @@ const MobileMenuContainer = styled.div<MenuConstructProps>(({ theme, sx }) => {
     "& .menuHeaderContainer": {
       cursor: "pointer",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   };
 });
 

--- a/src/components/Menu/Vertical/VerticalMenu.tsx
+++ b/src/components/Menu/Vertical/VerticalMenu.tsx
@@ -27,6 +27,7 @@ import MenuSectionHeader from "./MenuSectionHeader";
 import LogoutIcon from "../../Icons/LogoutIcon";
 import Tooltip from "../../Tooltip/Tooltip";
 import MinIOTierIconXs from "../../Icons/MinIOTierIconXs";
+import { overridePropsParse } from "../../../global/utils";
 
 const VerticalMenuDrawer = styled.div<MenuConstructProps>(({ theme, sx }) => {
   return {
@@ -195,7 +196,7 @@ const VerticalMenuDrawer = styled.div<MenuConstructProps>(({ theme, sx }) => {
         transform: "translateX(50%) translateY(20%)",
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   };
 });
 

--- a/src/components/ModalBox/ModalBox.tsx
+++ b/src/components/ModalBox/ModalBox.tsx
@@ -23,9 +23,17 @@ import { ModalBoxContainerProps, ModalBoxProps } from "./ModalBox.types";
 import Box from "../Box/Box";
 import AlertCloseIcon from "../Icons/AlertCloseIcon";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const ModalBoxContainer = styled.div<ModalBoxContainerProps>(
-  ({ theme, backgroundOverlay, widthLimit, iconColor, customMaxWidth }) => ({
+  ({
+    theme,
+    backgroundOverlay,
+    widthLimit,
+    iconColor,
+    customMaxWidth,
+    sx,
+  }) => ({
     "& .overlay": {
       position: "fixed" as const,
       zIndex: 1200,
@@ -111,6 +119,7 @@ const ModalBoxContainer = styled.div<ModalBoxContainerProps>(
       maxHeight: "calc(100vh - 150px)",
       overflowY: "auto",
     },
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ModalBox/ModalBox.types.ts
+++ b/src/components/ModalBox/ModalBox.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ModalBoxProps {
   onClose: () => void;
@@ -27,7 +27,7 @@ export interface ModalBoxProps {
   backgroundOverlay?: boolean;
   iconColor?: "accept" | "delete" | "default";
   customMaxWidth?: number | string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ModalBoxContainerProps {
@@ -35,5 +35,5 @@ export interface ModalBoxContainerProps {
   widthLimit?: boolean;
   iconColor?: "accept" | "delete" | "default";
   customMaxWidth?: number | string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -19,7 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { PageHeaderConstruct, PageHeaderProps } from "./PageHeader.types";
 import Grid from "../Grid/Grid";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 
 const ParentContainer = styled.div<
   PageHeaderConstruct & HTMLAttributes<HTMLDivElement>
@@ -50,7 +50,7 @@ const ParentContainer = styled.div<
     fontWeight: "bold",
     lineHeight: " 28px",
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const LabelContainer = styled.div<HTMLAttributes<HTMLDivElement>>(

--- a/src/components/PageHeader/PageHeader.types.ts
+++ b/src/components/PageHeader/PageHeader.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface PageHeaderMainProps {
   label: React.ReactNode;
@@ -24,7 +24,7 @@ export interface PageHeaderMainProps {
 }
 
 export interface PageHeaderConstruct {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type PageHeaderProps = PageHeaderMainProps & PageHeaderConstruct;

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -18,6 +18,7 @@ import React, { FC, HTMLAttributes } from "react";
 import styled from "styled-components";
 import { PageLayoutProps } from "./PageLayout.types";
 import Grid from "../Grid/Grid";
+import { overridePropsParse } from "../../global/utils";
 
 const PageLayoutContainer = styled.div<
   HTMLAttributes<HTMLDivElement> & PageLayoutProps
@@ -25,7 +26,7 @@ const PageLayoutContainer = styled.div<
   boxSizing: "content-box",
   maxWidth: variant === "constrained" ? 1220 : "initial",
   padding: 32,
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const PageLayout: FC<PageLayoutProps & HTMLAttributes<HTMLDivElement>> = ({

--- a/src/components/PageLayout/PageLayout.types.ts
+++ b/src/components/PageLayout/PageLayout.types.ts
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface PageLayoutProps {
   variant?: "constrained" | "full";
   children: React.ReactNode;
   className?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import { PillProps } from "./Pill.types";
 import { themeColors } from "../../global/themeColors";
 import get from "lodash/get";
+import { overridePropsParse } from "../../global/utils";
 
 const PillBase = styled.span<PillProps>(({ theme, sx, type }) => ({
   backgroundColor: get(
@@ -42,7 +43,7 @@ const PillBase = styled.span<PillProps>(({ theme, sx, type }) => ({
   borderRadius: 4,
   whiteSpace: "nowrap",
   userSelect: "none",
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const Pill: FC<PillProps & React.HTMLAttributes<HTMLSpanElement>> = ({

--- a/src/components/Pill/Pill.types.ts
+++ b/src/components/Pill/Pill.types.ts
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface PillProps {
   type: "current" | "secondary" | "default";
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -20,6 +20,7 @@ import get from "lodash/get";
 import { CommonProgressBar, ProgressBarProps } from "./ProgressBar.types";
 import { lightColors } from "../../global/themes";
 import Box from "../Box/Box";
+import { overridePropsParse } from "../../global/utils";
 
 const colorItems = {
   blue: "main",
@@ -65,7 +66,7 @@ const ProgressBase = styled.div<CommonProgressBar>(
       transitionDuration: "0.1s",
       borderRadius: barHeight,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ProgressBar/ProgressBar.types.ts
+++ b/src/components/ProgressBar/ProgressBar.types.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface MainProgressProps {
   variant?: "determinate" | "indeterminate";
@@ -25,7 +25,7 @@ export interface MainProgressProps {
 }
 
 export interface CommonProgressBar {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   color?: "blue" | "red" | "green" | "orange" | "grey";
   barHeight?: number;
   transparentBG?: boolean;

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -24,6 +24,7 @@ import FieldContainer from "../../global/FieldContainer";
 import Tooltip from "../Tooltip/Tooltip";
 import HelpIcon from "../Icons/HelpIcon";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const RadioButton = styled.label<InputLabelProps>(({ sx, theme }) => ({
   "& input": {
@@ -64,7 +65,7 @@ const RadioButton = styled.label<InputLabelProps>(({ sx, theme }) => ({
       },
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const OptionsContainer = styled.div<OptionsContainerProps>(

--- a/src/components/RadioGroup/RadioGroup.types.ts
+++ b/src/components/RadioGroup/RadioGroup.types.ts
@@ -15,8 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
-import { SelectorType } from "../../global/global.types";
+import { OverrideTheme, SelectorType } from "../../global/global.types";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
 
 export interface RadioGroupProps {
@@ -33,7 +32,7 @@ export interface RadioGroupProps {
     event: React.ChangeEvent<HTMLInputElement>,
     extraValue?: any,
   ) => void;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }

--- a/src/components/ReadBox/ReadBox.tsx
+++ b/src/components/ReadBox/ReadBox.tsx
@@ -20,6 +20,7 @@ import get from "lodash/get";
 import { ReadBoxBaseProps, ReadBoxProps } from "./ReadBox.types";
 import InputLabel from "../InputLabel/InputLabel";
 import Box from "../Box/Box";
+import { overridePropsParse } from "../../global/utils";
 
 const ReadBoxBase = styled.div<ReadBoxBaseProps>(
   ({ theme, sx, label, multiLine }) => ({
@@ -66,7 +67,7 @@ const ReadBoxBase = styled.div<ReadBoxBaseProps>(
       top: "50%",
       transform: "translate(0, -50%)",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ReadBox/ReadBox.types.ts
+++ b/src/components/ReadBox/ReadBox.types.ts
@@ -15,21 +15,21 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ReadBoxProps {
   label?: string;
   children: React.ReactNode;
   multiLine?: boolean;
   actionButton?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }
 
 export interface ReadBoxBaseProps {
   label?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   multiLine?: boolean;
 }

--- a/src/components/RoundedButton/RoundedButton.tsx
+++ b/src/components/RoundedButton/RoundedButton.tsx
@@ -17,7 +17,7 @@
 import React, { FC, Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 import { ButtonProps, ConstructProps } from "../Button/Button.types";
 
 const RoundedCustomButton = styled.button<
@@ -211,7 +211,7 @@ const RoundedCustomButton = styled.button<
         },
       },
       ...smallScreenStyles,
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/ScreenTitle/ScreenTitle.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.tsx
@@ -19,7 +19,7 @@ import {
   ScreenTitleContainerProps,
   ScreenTitleProps,
 } from "./ScreenTitle.types";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 import styled from "styled-components";
 import Box from "../Box/Box";
 import get from "lodash/get";
@@ -133,7 +133,7 @@ const ScreenTitleContainer = styled.div<ScreenTitleContainerProps>(
         },
       },
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ScreenTitle/ScreenTitle.types.ts
+++ b/src/components/ScreenTitle/ScreenTitle.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ScreenTitleProps {
   icon: React.ReactNode;
@@ -23,13 +23,13 @@ export interface ScreenTitleProps {
   title: string;
   actions: React.ReactNode;
   titleOptions?: ScreenTitleOptions[];
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface ScreenTitleContainerProps {
   subTitle?: React.ReactNode;
   titleOptions?: ScreenTitleOptions[];
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   bottomBorder?: boolean;
 }
 

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -20,6 +20,7 @@ import { SearchBoxProps } from "./SearchBox.types";
 import SearchIcon from "../Icons/SearchIcon";
 import get from "lodash/get";
 import { themeColors } from "../../global/themeColors";
+import { overridePropsParse } from "../../global/utils";
 
 const SearchBoxContainer = styled.div(({ theme }) => ({
   position: "relative",
@@ -41,7 +42,7 @@ const SearchBoxContainer = styled.div(({ theme }) => ({
   },
 }));
 
-const SearchBoxBase = styled.input<SearchBoxProps>(({ theme }) => {
+const SearchBoxBase = styled.input<SearchBoxProps>(({ sx, theme }) => {
   let borderColor = get(
     theme,
     "inputBox.border",
@@ -117,6 +118,7 @@ const SearchBoxBase = styled.input<SearchBoxProps>(({ theme }) => {
         ),
       },
     },
+    ...overridePropsParse(sx, theme),
   };
 });
 

--- a/src/components/SearchBox/SearchBox.types.ts
+++ b/src/components/SearchBox/SearchBox.types.ts
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface SearchBoxProps {
   id: string;
   placeholder?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   icon?: React.ReactNode;
 }

--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -18,7 +18,7 @@ import React, { FC, HTMLAttributes } from "react";
 import Grid from "../Grid/Grid";
 import { SectionTitleProps } from "./SectionTitle.types";
 import styled from "styled-components";
-import get from "lodash/get";
+import { overridePropsParse } from "../../global/utils";
 
 const SectionParent = styled.div<
   HTMLAttributes<HTMLDivElement> & SectionTitleProps
@@ -27,7 +27,7 @@ const SectionParent = styled.div<
   alignItems: "center",
   justifyContent: "flex-start",
   gap: "10px",
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const SectionTitle: FC<SectionTitleProps & HTMLAttributes<HTMLDivElement>> = ({

--- a/src/components/SectionTitle/SectionTitle.types.ts
+++ b/src/components/SectionTitle/SectionTitle.types.ts
@@ -15,12 +15,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface SectionTitleProps {
   separator?: boolean;
   actions?: React.ReactNode;
   icon?: React.ReactNode;
   children: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -26,6 +26,7 @@ import Box from "../Box/Box";
 import CollapseCaret from "../Icons/CollapseCaret";
 import ExpandCaret from "../Icons/ExpandCaret";
 import DropdownSelector from "../DropdownSelector/DropdownSelector";
+import { overridePropsParse } from "../../global/utils";
 
 const SelectBase = styled.div(({ theme }) => {
   let borderColor = get(theme, "inputBox.border", "#E2E2E2");
@@ -132,7 +133,7 @@ const InputContainer = styled.div<InputContainerProps>(
     "& .inputLabel": {
       marginBottom: error ? 18 : 0,
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
-import { SelectorType } from "../../global/global.types";
+import { OverrideTheme, SelectorType } from "../../global/global.types";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
 
 export interface SelectProps {
@@ -32,7 +31,7 @@ export interface SelectProps {
   fixedLabel?: string;
   placeholder?: string;
   onChange: (newValue: string, extraValue?: any) => void;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
 }

--- a/src/components/SimpleHeader/SimpleHeader.tsx
+++ b/src/components/SimpleHeader/SimpleHeader.tsx
@@ -22,6 +22,7 @@ import {
 } from "./SimpleHeader.types";
 import get from "lodash/get";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const ParentContainer = styled.div<
   HTMLAttributes<HTMLDivElement> & SimpleHeaderContainerProps
@@ -37,7 +38,7 @@ const ParentContainer = styled.div<
   fontWeight: 600,
   lineHeight: "18px",
   letterSpacing: "0.16px",
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const SimpleHeader: FC<SimpleHeaderProps & HTMLAttributes<HTMLDivElement>> = ({

--- a/src/components/SimpleHeader/SimpleHeader.types.ts
+++ b/src/components/SimpleHeader/SimpleHeader.types.ts
@@ -15,14 +15,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface SimpleHeaderProps {
   label: React.ReactNode;
   icon?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface SimpleHeaderContainerProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }

--- a/src/components/SizeChart/SizeChart.tsx
+++ b/src/components/SizeChart/SizeChart.tsx
@@ -19,7 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { SizeChartConstructProps, SizeChartProps } from "./SizeChart.types";
 import { lightColors } from "../../global/themes";
-import { calculateBytes } from "../../global/utils";
+import { calculateBytes, overridePropsParse } from "../../global/utils";
 
 const SizeChartBase = styled.svg<SVGProps<any> & SizeChartConstructProps>(
   ({ theme, usedBytes, totalBytes, chartLabel, sx }) => {
@@ -61,7 +61,7 @@ const SizeChartBase = styled.svg<SVGProps<any> & SizeChartConstructProps>(
         fontWeight: "bold",
         fill: get(theme, "mutedText", lightColors.mutedText),
       },
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/SizeChart/SizeChart.types.ts
+++ b/src/components/SizeChart/SizeChart.types.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface SizeChartMain {
   label: boolean;
@@ -26,7 +26,7 @@ export interface SizeChartConstructProps {
   usedBytes: number;
   totalBytes: number;
   chartLabel?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type SizeChartProps = SizeChartMain & SizeChartConstructProps;

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -23,6 +23,7 @@ import InputLabel from "../InputLabel/InputLabel";
 import Box from "../Box/Box";
 import { SliderContainerProps, SliderProps } from "./Slider.types";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const InputBase = styled.input(({ theme }) => {
   const thumb: CSSObject = {
@@ -107,7 +108,7 @@ const SliderContainer = styled.div<SliderContainerProps>(
       fontSize: 12,
       fontWeight: "bold",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Slider/Slider.types.ts
+++ b/src/components/Slider/Slider.types.ts
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface SliderProps {
   id: string;
@@ -24,7 +24,7 @@ export interface SliderProps {
   noLabelMinWidth?: boolean;
   error?: string;
   tooltip?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   helpTip?: React.ReactNode;
   helpTipPlacement?: CommonHelpTipPlacement;
   displayValue?: boolean;
@@ -33,7 +33,7 @@ export interface SliderProps {
 
 export interface SliderContainerProps {
   children?: React.ReactNode;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   error?: boolean;
   className?: string;
 }

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -26,6 +26,7 @@ import { createPortal } from "react-dom";
 import { lightColors } from "../../global/themes";
 import AlertCloseIcon from "../Icons/AlertCloseIcon";
 import Box from "../Box/Box";
+import { overridePropsParse } from "../../global/utils";
 
 const SnackBarContainer = styled.div<SnackbarConstructProps>(
   ({ theme, sx, open, variant, condensed }) => ({
@@ -62,7 +63,7 @@ const SnackBarContainer = styled.div<SnackbarConstructProps>(
       textOverflow: "ellipsis",
       textAlign: "center",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Snackbar/Snackbar.types.ts
+++ b/src/components/Snackbar/Snackbar.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ReactNode } from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface SnackbarMainProps {
   autoHideDuration?: number;
@@ -29,7 +29,7 @@ export interface SnackbarConstructProps {
   open: boolean;
   condensed?: boolean;
   variant?: "default" | "success" | "warning" | "error";
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface SnackbarButtonProps {

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -28,6 +28,7 @@ import HelpIcon from "../Icons/HelpIcon";
 import Box from "../Box/Box";
 import FieldContainer from "../../global/FieldContainer";
 import { lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const SwitchIndicator = styled.span<IndicatorProps>(({ theme, active }) => ({
   fontSize: 12,
@@ -129,7 +130,7 @@ const SwitchMainContainer = styled.div<SwitchContainerProps>(
       marginTop: 4,
       color: get(theme, "mutedText", lightV2.mutedText),
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Switch/Switch.types.ts
+++ b/src/components/Switch/Switch.types.ts
@@ -15,14 +15,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
 import { CommonHelpTipPlacement } from "../HelpTip/HelpTip.types";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface MainSwitchProps {
   id: string;
   label?: string;
   tooltip?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   className?: string;
   switchOnly?: boolean;
   indicatorLabels?: string[];
@@ -37,7 +37,7 @@ export interface IndicatorProps {
 }
 
 export interface SwitchContainerProps {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type SwitchProps = MainSwitchProps &

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -17,13 +17,14 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 import { TableComponentsExtraProps } from "./Table.types";
+import { overridePropsParse } from "../../global/utils";
 
 const TableMain = styled.table<TableComponentsExtraProps>(({ theme, sx }) => ({
   display: "table",
   width: "100%",
   borderCollapse: "collapse",
   borderSpacing: 0,
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const Table: FC<

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { CSSProperties } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface TableComponentsExtraProps {
-  sx?: CSSProperties;
+  sx?: OverrideTheme;
 }

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -17,6 +17,7 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 import { TableComponentsExtraProps } from "./Table.types";
+import { overridePropsParse } from "../../global/utils";
 
 const TableBodyMain = styled.tbody<TableComponentsExtraProps>(
   ({ theme, sx }) => ({
@@ -24,7 +25,7 @@ const TableBodyMain = styled.tbody<TableComponentsExtraProps>(
     width: "100%",
     borderCollapse: "collapse",
     borderSpacing: 0,
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import { TableComponentsExtraProps } from "./Table.types";
 import get from "lodash/get";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const TableCellMain = styled.td<TableComponentsExtraProps>(({ theme, sx }) => ({
   fontFamily: "'Geist',sans-serif",
@@ -35,7 +36,7 @@ const TableCellMain = styled.td<TableComponentsExtraProps>(({ theme, sx }) => ({
   textAlign: "left",
   padding: 16,
   color: get(theme, "secondaryText", lightColors.mainGrey),
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const TableCell: FC<

--- a/src/components/Table/TableHead.tsx
+++ b/src/components/Table/TableHead.tsx
@@ -17,6 +17,7 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 import { TableComponentsExtraProps } from "./Table.types";
+import { overridePropsParse } from "../../global/utils";
 
 const TableHeadMain = styled.thead<TableComponentsExtraProps>(
   ({ theme, sx }) => ({
@@ -24,7 +25,7 @@ const TableHeadMain = styled.thead<TableComponentsExtraProps>(
     width: "100%",
     borderCollapse: "collapse",
     borderSpacing: 0,
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Table/TableHeadCell.tsx
+++ b/src/components/Table/TableHeadCell.tsx
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { cloneElement, createElement, FC } from "react";
+import React, { FC } from "react";
 import styled from "styled-components";
 import { TableComponentsExtraProps } from "./Table.types";
 import get from "lodash/get";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const TableHeadCellMain = styled.th<TableComponentsExtraProps>(
   ({ theme, sx }) => ({
@@ -36,7 +37,7 @@ const TableHeadCellMain = styled.th<TableComponentsExtraProps>(
     padding: 16,
     fontWeight: "bold",
     color: get(theme, "secondaryText", lightColors.mainGrey),
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { TableComponentsExtraProps } from "./Table.types";
 import { lightColors } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const TableRowMain = styled.tr<TableComponentsExtraProps>(({ theme, sx }) => ({
   color: "inherit",
@@ -29,7 +30,7 @@ const TableRowMain = styled.tr<TableComponentsExtraProps>(({ theme, sx }) => ({
   borderLeft: 0,
   borderRight: 0,
   backgroundColor: get(theme, "bgColor", lightColors.white),
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const TableRow: FC<

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -22,6 +22,7 @@ import { lightColors, lightV2 } from "../../global/themes";
 import Box from "../Box/Box";
 import TabPanel from "./TabPanel";
 import TabButton from "./TabButton";
+import { overridePropsParse } from "../../global/utils";
 
 const TabsContainer = styled.div<TabsContainerProps>(
   ({ theme, horizontal, horizontalBarBackground, sx }) => {
@@ -84,7 +85,7 @@ const TabsContainer = styled.div<TabsContainerProps>(
             )} 1px solid`,
         borderLeft: "none",
       },
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -16,6 +16,7 @@
 
 import React from "react";
 import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface TabProps {
   label: string;
@@ -40,13 +41,13 @@ export interface TabsProps {
   optionsInitialComponent?: React.ReactNode;
   optionsEndComponent?: React.ReactNode;
   horizontalBarBackground?: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface TabsContainerProps {
   horizontal: boolean;
   horizontalBarBackground: boolean;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export interface TabButtonProps {

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -20,6 +20,7 @@ import get from "lodash/get";
 import { TagConstructProps, TagProps } from "./Tag.types";
 import AlertCloseIcon from "../Icons/AlertCloseIcon";
 import { lightColors, lightV2 } from "../../global/themes";
+import { overridePropsParse } from "../../global/utils";
 
 const TagBase = styled.span<TagConstructProps>(
   ({ theme, color, variant, square, sx }) => {
@@ -91,7 +92,7 @@ const TagBase = styled.span<TagConstructProps>(
           minHeight: 10,
         },
       },
-      ...sx,
+      ...overridePropsParse(sx, theme),
     };
   },
 );

--- a/src/components/Tag/Tag.types.ts
+++ b/src/components/Tag/Tag.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ReactNode } from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface TagMainProps {
   label: string;
@@ -26,7 +26,7 @@ export interface TagMainProps {
 
 export interface TagConstructProps {
   color?: "default" | "secondary" | "warn" | "alert" | "ok" | "grey";
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   variant?: "regular" | "outlined";
   square?: boolean;
 }

--- a/src/components/ValuePair/ValuePair.tsx
+++ b/src/components/ValuePair/ValuePair.tsx
@@ -19,7 +19,7 @@ import styled from "styled-components";
 import { ValuePairCommon, ValuePairProps } from "./ValuePair.types";
 import Box from "../Box/Box";
 import get from "lodash/get";
-import { breakPoints } from "../../global/utils";
+import { breakPoints, overridePropsParse } from "../../global/utils";
 import { lightV2 } from "../../global/themes";
 
 const ValuePairBase = styled.div<ValuePairCommon>(
@@ -43,7 +43,7 @@ const ValuePairBase = styled.div<ValuePairCommon>(
     [`@media (max-width: ${get(breakPoints, "md", 0)}px)`]: {
       flexDirection: "column",
     },
-    ...sx,
+    ...overridePropsParse(sx, theme),
   }),
 );
 

--- a/src/components/ValuePair/ValuePair.types.ts
+++ b/src/components/ValuePair/ValuePair.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ReactNode } from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface ValuePairMain {
   label?: ReactNode;
@@ -24,7 +24,7 @@ export interface ValuePairMain {
 
 export interface ValuePairCommon {
   direction?: "column" | "row";
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 export type ValuePairProps = ValuePairMain & ValuePairCommon;

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -21,6 +21,7 @@ import WizardPage from "./WizardPage";
 import { WizardConstruct, WizardProps } from "./Wizard.types";
 import { lightV2 } from "../../global/themes";
 import Box from "../Box/Box";
+import { overridePropsParse } from "../../global/utils";
 
 const WizardMain = styled.div<WizardConstruct>(({ theme, sx, forModal }) => ({
   position: "relative",
@@ -108,7 +109,7 @@ const WizardMain = styled.div<WizardConstruct>(({ theme, sx, forModal }) => ({
     justifyContent: "flex-start",
     gap: 16,
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 const GenericWizard = ({

--- a/src/components/Wizard/Wizard.types.ts
+++ b/src/components/Wizard/Wizard.types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
-import { CSSObject } from "styled-components";
+import { OverrideTheme } from "../../global/global.types";
 
 export interface WizardButton {
   label?: string;
@@ -47,7 +47,7 @@ export interface WizardMain {
 }
 
 export interface WizardConstruct {
-  sx?: CSSObject;
+  sx?: OverrideTheme;
   forModal?: boolean;
   actionButtonsPortalID?: HTMLElement;
 }

--- a/src/global/FieldContainer.tsx
+++ b/src/global/FieldContainer.tsx
@@ -15,18 +15,19 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { FC, HTMLAttributes } from "react";
-import { breakPoints } from "./utils";
-import styled, { CSSObject } from "styled-components";
+import { breakPoints, overridePropsParse } from "./utils";
+import styled from "styled-components";
+import { OverrideTheme } from "./global.types";
 
 export interface FieldContainerProps {
   children: React.ReactNode;
   className?: string;
-  sx?: CSSObject;
+  sx?: OverrideTheme;
 }
 
 const MainContainer = styled.div<
   HTMLAttributes<HTMLDivElement> & FieldContainerProps
->(({ sx }) => ({
+>(({ sx, theme }) => ({
   position: "relative",
   display: "flex",
   flexWrap: "wrap",
@@ -43,7 +44,7 @@ const MainContainer = styled.div<
       width: 13,
     },
   },
-  ...sx,
+  ...overridePropsParse(sx, theme),
 }));
 
 export const FieldContainer: FC<FieldContainerProps> = ({

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
+import { CSSObject } from "styled-components";
 
 export interface ThemeColorItem {
   [key: string]: ColorVariant;
@@ -480,3 +481,10 @@ export interface IBytesCalc {
   total: number;
   unit: string;
 }
+
+// Components Styling Override type
+
+export type OverrideTheme =
+  | CSSObject
+  | ((theme: ThemeDefinitionProps) => CSSObject)
+  | undefined;

--- a/src/global/utils.ts
+++ b/src/global/utils.ts
@@ -14,7 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { ColorVariant, IBytesCalc } from "./global.types";
+import {
+  ColorVariant,
+  IBytesCalc,
+  OverrideTheme,
+  ThemeDefinitionProps,
+} from "./global.types";
 import { themeColors } from "./themeColors";
 
 export const breakPoints = { xs: 0, sm: 576, md: 768, lg: 992, xl: 1200 };
@@ -105,4 +110,18 @@ export const getThemeColors = (
   });
 
   return returnItem;
+};
+
+export const overridePropsParse = (
+  overrideValue: OverrideTheme,
+  theme: ThemeDefinitionProps,
+) => {
+  if (overrideValue) {
+    // Override is a function, we need to evaluate
+    if (overrideValue instanceof Function) {
+      return overrideValue(theme);
+    }
+
+    return overrideValue;
+  }
 };


### PR DESCRIPTION
## What does this do?

Implemented theming support in `sx` override properties, now we can use a CSSObject, or a function that can read through theme variables and return the correct CSS Object

Eg.
```ts
sx={(theme) => ({
        backgroundColor: theme.colors["Color/Base/Royal/9"],
        color: theme.colors["Color/Base/Royal/0"],
      })}
```