### PR TITLE
Adjusted ButtonGroup buttons width

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -35,7 +35,7 @@ const ButtonGroupMain = styled.div<ButtonGroupProps>(
     borderRadius: 4,
     overflow: "hidden",
     width: "initial",
-    height: 28,
+    height: 30,
     boxSizing: "border-box" as const,
     "& > *:not(:last-child)": {
       borderRight: `1px solid   ${get(theme, "buttonGroup.border", themeColors["Color/Neutral/Border/colorBorderMinimal"].lightMode)}`,
@@ -53,14 +53,15 @@ const ButtonGroupMain = styled.div<ButtonGroupProps>(
       fontWeight: 400,
       letterSpacing: "0.16px",
       fontFamily: "'Geist', sans-serif",
+      boxSizing: "border-box",
       color: get(
         theme,
         "buttonGroup.labelColor",
         themeColors["Color/Neutral/Text/colorTextSecondary"].lightMode,
       ),
-      padding: displayLabels ? "4px 12px" : "0 6px",
-      height: 26,
-      width: displayLabels ? "initial" : 44,
+      padding: displayLabels ? "4px 12px" : 6,
+      height: 28,
+      width: displayLabels ? "initial" : 28,
       gap: 4,
       background: "transparent",
       "& .buttonIcon": {


### PR DESCRIPTION
## What does this do?

Adjusted ButtonGroup buttons width according design 

## How does it look?

<img width="1458" alt="Screenshot 2024-05-16 at 10 01 20 p m" src="https://github.com/minio/mds/assets/33497058/f8d83e94-572f-430a-8fb3-39345b2aea02">
<img width="907" alt="Screenshot 2024-05-16 at 10 01 03 p m" src="https://github.com/minio/mds/assets/33497058/c86608f3-dedc-4ee8-930a-e87355930471">
