### PR TITLE
Fixed minor button sizes

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -34,18 +34,6 @@ const Template: Story<ButtonProps> = (args) => (
   <StoryThemeProvider>
     <GlobalStyles />
     <Button {...args} onClick={() => alert("You clicked me!")} />
-    <br />
-    <Button {...args}>With Children</Button>
-    <br />
-    <Button
-      id={"asdf"}
-      sx={(theme) => ({
-        backgroundColor: theme.colors["Color/Base/Royal/9"],
-        color: theme.colors["Color/Base/Royal/0"],
-      })}
-    >
-      Func
-    </Button>
   </StoryThemeProvider>
 );
 
@@ -130,4 +118,12 @@ IconOnly.args = {
   disabled: false,
   variant: "regular",
   icon: <TestIcon />,
+};
+
+export const IconOnlyCompact = Template.bind({});
+IconOnlyCompact.args = {
+  disabled: false,
+  variant: "regular",
+  icon: <TestIcon />,
+  compact: true,
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -68,11 +68,17 @@ const CustomButton = styled.button<
     const padding =
       (!label || label.trim() === "") && !parentChildren ? "0 12px" : "0 25px";
 
+    let calculatedWidth = "initial";
+
+    if (!parentChildren && label?.trim() === "") {
+      calculatedWidth = compact ? "28px" : "36px";
+    }
+
     return {
       borderRadius: 6,
       cursor: "pointer",
-      width: fullWidth ? "100%" : "initial",
-      height: compact ? 28 : 32,
+      width: fullWidth ? "100%" : calculatedWidth,
+      height: compact ? 28 : 36,
       fontFamily: "'Geist', sans-serif",
       fontWeight: compact ? "normal" : "600",
       fontSize: 14,
@@ -208,11 +214,14 @@ const Button: FC<
     >
       <Fragment>
         {icon && iconLocation === "start" && iconToPlace}
-        <span className={"button-label"}>
-          {children}
-          {children && label ? " " : ""}
-          {label}
-        </span>
+        {children ||
+          (label?.trim() !== "" && (
+            <span className={"button-label"}>
+              {children}
+              {children && label ? " " : ""}
+              {label}
+            </span>
+          ))}
         {icon && iconLocation === "end" && iconToPlace}
       </Fragment>
     </CustomButton>


### PR DESCRIPTION
## What does this do?

Fixed button sizes for icon only variants

> NOTE: Colors adjustments will be handled in a second PR as there are some inconsistencies in the names of the colors in Figma

## How does it look?

<img width="971" alt="Screenshot 2024-05-17 at 5 26 48 p m" src="https://github.com/minio/mds/assets/33497058/39d3e8e3-74ef-4e42-b7a6-55a1e186d529">
<img width="851" alt="Screenshot 2024-05-17 at 5 26 44 p m" src="https://github.com/minio/mds/assets/33497058/6b1a6ea3-b7cd-47aa-be96-4fcba19844f3">
