### PR TITLE
Added Dropdown compatibility to Breadcrumbs component

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbButton.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbButton.tsx
@@ -15,11 +15,15 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { FC, Fragment } from "react";
-import { BreadcrumbsOptionProps } from "./Breadcrumbs.types";
+import { BreadcrumbsOption, BreadcrumbsOptionProps } from "./Breadcrumbs.types";
 import styled from "styled-components";
 import { ButtonProps, ConstructProps } from "../Button/Button.types";
 import get from "lodash/get";
 import { themeColors } from "../../global/themeColors";
+import ExpandOptionsIcon from "../Icons/ExpandOptionsIcon";
+import ExpandMenuOption from "../ExpandMenu/ExpandMenuOption";
+import ExpandMenu from "../ExpandMenu/ExpandMenu";
+import ExpandCaret from "../Icons/ExpandCaret";
 
 const CustomBreadcrumb = styled.button<
   ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement> & ConstructProps
@@ -105,12 +109,88 @@ const BreadcrumbButton: FC<
   children,
   className,
   current,
+  subOptions,
   ...props
 }) => {
+  const clickFunction = (option: BreadcrumbsOption) => {
+    if (option.onClick) {
+      option.onClick(option.to);
+    }
+  };
+
   let iconToPlace: React.ReactNode = null;
 
   if (icon) {
     iconToPlace = <span className={"buttonIcon"}>{icon}</span>;
+  }
+
+  if (subOptions) {
+    return (
+      <ExpandMenu
+        id={`expand-breadcrumb-${label}`}
+        className={"breadcrumbElement"}
+        icon={icon}
+        label={label}
+        variant={"text"}
+        sx={(theme) => ({
+          display: "flex",
+          alignItems: "center",
+          height: 20,
+          padding: "2px 4px",
+          borderRadius: 2,
+          fontSize: 12,
+          gap: 4,
+          transitionDuration: "0s",
+          color: get(
+            theme,
+            "breadcrumbs.elementsColor",
+            themeColors["Color/Neutral/Text/colorTextDescription"].lightMode,
+          ),
+          "&:hover": {
+            backgroundColor: get(
+              theme,
+              "breadcrumbs.hoverBG",
+              themeColors["Color/Brand/Control/colorBgHover"].lightMode,
+            ),
+            color: get(
+              theme,
+              "breadcrumbs.hoverColor",
+              themeColors["Color/Neutral/Text/colorTextLabel"].lightMode,
+            ),
+            textDecoration: "underline",
+            "& .button-icon svg": {
+              color: get(
+                theme,
+                "breadcrumbs.hoverColor",
+                themeColors["Color/Neutral/Text/colorTextLabel"].lightMode,
+              ),
+            },
+          },
+          "& .buttonIcon > svg": {
+            color: get(
+              theme,
+              "breadcrumbs.elementsColor",
+              themeColors["Color/Neutral/Text/colorTextDescription"].lightMode,
+            ),
+            width: 16,
+            height: 16,
+          },
+          "& .button-label": {
+            marginLeft: 0,
+          },
+        })}
+        compact
+      >
+        {subOptions.map((option) => (
+          <ExpandMenuOption
+            id={`expandOption-${option.label}`}
+            onClick={() => clickFunction(option)}
+          >
+            {option.label}
+          </ExpandMenuOption>
+        ))}
+      </ExpandMenu>
+    );
   }
 
   return (
@@ -121,7 +201,7 @@ const BreadcrumbButton: FC<
       label={label || ""}
       icon={iconToPlace}
       parentChildren={children || null}
-      className={`breadcrumbElement ${className || ""} ${current ? "current" : ""}`}
+      className={`breadcrumbElement ${className || ""} ${current && !subOptions ? "current" : ""}`}
       {...props}
     >
       <Fragment>

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -24,6 +24,7 @@ import StoryThemeProvider from "../../utils/StoryThemeProvider";
 import { GlobalStyles } from "../index";
 import TestIcon from "../../utils/TestIcon";
 import HomeIcon from "../Icons/NewDesignIcons/HomeIcon";
+import { EyeIcon } from "../Icons/NewDesignIcons";
 
 export default {
   title: "MDS/Layout/Breadcrumbs",
@@ -56,6 +57,65 @@ const iconOptions: BreadcrumbsOption[] = [
   { label: "Level 4", to: "/lol" },
   { label: "Level 5", to: "/lol" },
   { label: "Level 6", to: "/lol" },
+];
+
+const subMenuOptions: BreadcrumbsOption[] = [
+  { icon: <HomeIcon />, to: "/lol" },
+  {
+    icon: <EyeIcon />,
+    label: "Level 1",
+    to: "/lol",
+    subOptions: [
+      {
+        label: "SubLevel 1",
+        to: "/lol",
+        onClick: (dt) => {
+          console.log("clicked", dt);
+        },
+      },
+      { label: "SubLevel 2", to: "/lol" },
+      { label: "SubLevel 3", to: "/lol" },
+      { label: "SubLevel 4", to: "/lol" },
+      { label: "SubLevel 5", to: "/lol" },
+    ],
+  },
+  { label: "Level 2", to: "/lol" },
+  {
+    label: "Level 3",
+    to: "/lol",
+    subOptions: [
+      {
+        label: "SubLevel 1",
+        to: "/lol",
+        onClick: (dt) => {
+          console.log("clicked", dt);
+        },
+      },
+      { label: "SubLevel 2", to: "/lol" },
+      { label: "SubLevel 3", to: "/lol" },
+      { label: "SubLevel 4", to: "/lol" },
+      { label: "SubLevel 5", to: "/lol" },
+    ],
+  },
+  { label: "Level 4", to: "/lol" },
+  { label: "Level 5", to: "/lol" },
+  {
+    label: "Level 6",
+    to: "/lol",
+    subOptions: [
+      {
+        label: "SubLevel 1",
+        to: "/lol",
+        onClick: (dt) => {
+          console.log("clicked", dt);
+        },
+      },
+      { label: "SubLevel 2", to: "/lol" },
+      { label: "SubLevel 3", to: "/lol" },
+      { label: "SubLevel 4", to: "/lol" },
+      { label: "SubLevel 5", to: "/lol" },
+    ],
+  },
 ];
 
 export const Default = Template.bind({});
@@ -93,5 +153,11 @@ LimitAsListSize.args = {
 export const WithIcons = Template.bind({});
 WithIcons.args = {
   options: iconOptions,
+  markCurrentItem: true,
+};
+
+export const WithSubMenus = Template.bind({});
+WithSubMenus.args = {
+  options: subMenuOptions,
   markCurrentItem: true,
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -140,6 +140,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
           padding: "2px 4px",
           borderRadius: 2,
         }}
+        dropArrow={false}
         compact
       >
         {colOpts.map((option) => (
@@ -195,12 +196,11 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
                   <BreadcrumbButton
                     id={`breadcrumb-option-${itm.label}`}
                     onClick={() => clickFunction(itm)}
-                    className={`${lastItem ? "last" : ""}`}
+                    className={`${lastItem && !itm.subOptions ? "last" : ""}`}
                     icon={itm.icon!!}
                     current={lastItem && markCurrentItem}
-                  >
-                    {itm.label}
-                  </BreadcrumbButton>
+                    label={itm.label}
+                  />
                 </Fragment>
               );
             })}
@@ -218,12 +218,12 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
                     onClick={() => {
                       clickFunction(itm);
                     }}
-                    className={`${lastItem ? "last" : ""}`}
+                    className={`${lastItem && !itm.subOptions ? "last" : ""}`}
                     icon={itm.icon!!}
                     current={lastItem && markCurrentItem}
-                  >
-                    {itm.label}
-                  </BreadcrumbButton>
+                    subOptions={itm.subOptions}
+                    label={itm.label}
+                  />
                 </Fragment>
               );
             })}

--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -32,6 +32,7 @@ export interface BreadcrumbsOption {
   to?: string;
   onClick?: (to?: string) => void;
   icon?: ReactNode;
+  subOptions?: BreadcrumbsOption[];
 }
 
 export interface BreadcrumbsContainerProps {
@@ -49,4 +50,5 @@ export interface BreadcrumbsOptionProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
   children?: ReactNode | string;
   sx?: OverrideTheme;
+  subOptions?: BreadcrumbsOption[];
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -75,7 +75,6 @@ const CustomButton = styled.button<
       flexDirection: "row",
       alignItems: "center",
       justifyContent: "center",
-      textTransform: variant === "text" ? "uppercase" : "none",
       margin: 0,
       padding:
         !label || label === ""
@@ -157,6 +156,7 @@ const Button: FC<
   variant = "neutral",
   icon,
   iconLocation = "start",
+  secondaryIcon,
   onClick,
   disabled,
   fullWidth,
@@ -169,9 +169,16 @@ const Button: FC<
   ...props
 }) => {
   let iconToPlace: React.ReactNode = null;
+  let secondaryIconToPlace: React.ReactNode = null;
 
   if (icon) {
     iconToPlace = <span className={"buttonIcon"}>{icon}</span>;
+  }
+
+  if (secondaryIcon) {
+    secondaryIconToPlace = (
+      <span className={"buttonIcon"}>{secondaryIcon}</span>
+    );
   }
 
   return (
@@ -182,7 +189,7 @@ const Button: FC<
       iconLocation={iconLocation || "end"}
       label={label}
       fullWidth={fullWidth || false}
-      collapseOnSmall={!!collapseOnSmall}
+      collapseOnSmall={collapseOnSmall}
       icon={iconToPlace}
       parentChildren={children || null}
       className={`${className || ""} button button-${variant}`}
@@ -201,6 +208,7 @@ const Button: FC<
           </span>
         )}
         {icon && iconLocation === "end" && iconToPlace}
+        {secondaryIcon && secondaryIconToPlace}
       </Fragment>
     </CustomButton>
   );

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -30,6 +30,7 @@ export interface ButtonProps {
     | "subAction";
   icon?: ReactNode;
   iconLocation?: "start" | "end";
+  secondaryIcon?: ReactNode;
   fullWidth?: boolean;
   disabled?: boolean;
   collapseOnSmall?: boolean;

--- a/src/components/ExpandMenu/ExpandMenu.tsx
+++ b/src/components/ExpandMenu/ExpandMenu.tsx
@@ -18,6 +18,8 @@ import React, { FC, Fragment, useState } from "react";
 import { ExpandMenuProps } from "./ExpandMenu.types";
 import Button from "../Button/Button";
 import ExpandDropdown from "./ExpandDropdown";
+import ChevronUpIcon from "../Icons/NewDesignIcons/ChevronUpIcon";
+import ChevronDownIcon from "../Icons/NewDesignIcons/ChevronDownIcon";
 
 const ExpandMenu: FC<
   ExpandMenuProps & React.ButtonHTMLAttributes<HTMLButtonElement>
@@ -32,6 +34,7 @@ const ExpandMenu: FC<
   label,
   children,
   disabled,
+  dropArrow = true,
   compact = false,
 }) => {
   const [expandedMenu, setExpandedMenu] = useState<boolean>(false);
@@ -39,12 +42,23 @@ const ExpandMenu: FC<
     (EventTarget & HTMLButtonElement) | null
   >(null);
 
+  let secondary = null;
+
+  if (dropArrow) {
+    secondary = expandedMenu ? (
+      <ChevronUpIcon style={{ fill: "none" }} />
+    ) : (
+      <ChevronDownIcon style={{ fill: "none" }} />
+    );
+  }
+
   return (
     <Fragment>
       <Button
         id={id}
         icon={icon}
         iconLocation={iconLocation}
+        secondaryIcon={secondary}
         variant={variant}
         name={name}
         sx={sx}

--- a/src/components/ExpandMenu/ExpandMenu.types.ts
+++ b/src/components/ExpandMenu/ExpandMenu.types.ts
@@ -33,6 +33,7 @@ export interface ExpandMenuProps {
   children?: ReactNode | string;
   dropMenuPosition?: "start" | "end";
   compact?: boolean;
+  dropArrow?: boolean;
   sx?: OverrideTheme;
 }
 

--- a/src/components/Icons/NewDesignIcons/ChevronDownIcon.tsx
+++ b/src/components/Icons/NewDesignIcons/ChevronDownIcon.tsx
@@ -1,0 +1,40 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as React from "react";
+import { SVGProps } from "react";
+
+const ChevronDownIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    fill="none"
+    className={`min-icon`}
+    {...props}
+  >
+    <path
+      id="Vector"
+      d="M4 6L8 10L12 6"
+      stroke="currentColor"
+      strokeOpacity="0.65"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default ChevronDownIcon;

--- a/src/components/Icons/NewDesignIcons/ChevronUpIcon.tsx
+++ b/src/components/Icons/NewDesignIcons/ChevronUpIcon.tsx
@@ -1,0 +1,40 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as React from "react";
+import { SVGProps } from "react";
+
+const ChevronUpIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    fill="none"
+    className={`min-icon`}
+    {...props}
+  >
+    <path
+      id="Vector"
+      d="M12 10L8 6L4 10"
+      stroke="currentColor"
+      strokeOpacity="0.65"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default ChevronUpIcon;

--- a/src/components/Icons/NewDesignIcons/index.ts
+++ b/src/components/Icons/NewDesignIcons/index.ts
@@ -44,3 +44,6 @@ export { default as ChevronLeftIcon } from "./ChevronLeftIcon";
 export { default as ChevronRightIcon } from "./ChevronRightIcon";
 export { default as EllipsisIcon } from "./EllipsisIcon";
 export { default as DeleteIcon } from "./DeleteIcon";
+export { default as ChevronDownIcon } from "./ChevronDownIcon";
+export { default as ChevronUpIcon } from "./ChevronUpIcon";
+export { default as HomeIcon } from "./HomeIcon";


### PR DESCRIPTION
## What does this do?

Added Dropdown compoatibility to Breadcrumbs component

## How does it look?

<img width="1189" alt="Screenshot 2024-05-21 at 10 49 28 p m" src="https://github.com/minio/mds/assets/33497058/e4327355-d410-4190-9c34-f37329590fb2">
<img width="1247" alt="Screenshot 2024-05-21 at 10 49 22 p m" src="https://github.com/minio/mds/assets/33497058/cd4a3cf2-e445-4866-a9d5-8718f2066d3c">
<img width="1257" alt="Screenshot 2024-05-21 at 10 49 18 p m" src="https://github.com/minio/mds/assets/33497058/6374c28e-ca2d-4ee2-858d-a20ba0aa95a3">
