### PR TITLE
Enabled dropdown icons support in Breadcrumbs drop menu

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbButton.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbButton.tsx
@@ -181,10 +181,12 @@ const BreadcrumbButton: FC<
         })}
         compact
       >
-        {subOptions.map((option) => (
+        {subOptions.map((option, index) => (
           <ExpandMenuOption
+            key={`expand-opt-${option.label}-${index}`}
             id={`expandOption-${option.label}`}
             onClick={() => clickFunction(option)}
+            icon={option.icon}
           >
             {option.label}
           </ExpandMenuOption>

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -91,9 +91,9 @@ const subMenuOptions: BreadcrumbsOption[] = [
           console.log("clicked", dt);
         },
       },
-      { label: "SubLevel 2", to: "/lol" },
+      { label: "SubLevel 2", to: "/lol", icon: <TestIcon /> },
       { label: "SubLevel 3", to: "/lol" },
-      { label: "SubLevel 4", to: "/lol" },
+      { label: "SubLevel 4", to: "/lol", icon: <TestIcon /> },
       { label: "SubLevel 5", to: "/lol" },
     ],
   },

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -143,8 +143,9 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
         dropArrow={false}
         compact
       >
-        {colOpts.map((option) => (
+        {colOpts.map((option, index) => (
           <ExpandMenuOption
+            key={`expandOption-${option.label}-${index}`}
             id={`expandOption-${option.label}`}
             onClick={() => clickFunction(option)}
           >
@@ -191,7 +192,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
               const lastItem = index === itSlide.length - 1;
 
               return (
-                <Fragment>
+                <Fragment key={`expandOption-${itm.label}-${index}`}>
                   {index !== 0 && <Divider />}
                   <BreadcrumbButton
                     id={`breadcrumb-option-${itm.label}`}
@@ -211,7 +212,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
               const lastItem = index === options.length - 1;
 
               return (
-                <Fragment>
+                <Fragment key={`expandOption-${itm.label}-${index}`}>
                   {index !== 0 && <Divider />}
                   <BreadcrumbButton
                     id={`breadcrumb-option-${itm.label}`}


### PR DESCRIPTION
## What does this do?

Enabled dropdown icons support in Breadcrumbs drop menu

## How does it look?

<img width="812" alt="Screenshot 2024-05-22 at 11 49 25 a m" src="https://github.com/minio/mds/assets/33497058/4ec007ec-c71f-4551-b8c1-9573db64f170">
