### PR TITLE
Box component updates

### DIFF
--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -68,6 +68,12 @@ WithCustomBorderPadding.args = {
   customBorderPadding: "5px 100px",
 };
 
+export const WithCustomBorderRadius = Template.bind({});
+WithCustomBorderRadius.args = {
+  withBorders: true,
+  customBorderRadius: 8,
+};
+
 export const BoxWithCustomStyles = Template.bind({});
 BoxWithCustomStyles.args = {
   withBorders: true,

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -22,14 +22,21 @@ import { lightV2 } from "../../global/themes";
 import { overridePropsParse } from "../../global/utils";
 
 const BoxParent = styled.div<BoxProps & React.HTMLAttributes<HTMLDivElement>>(
-  ({ theme, sx, withBorders, customBorderPadding, useBackground }) => {
+  ({
+    theme,
+    sx,
+    withBorders,
+    customBorderPadding,
+    customBorderRadius,
+    useBackground,
+  }) => {
     let extraBorders = {};
 
     if (withBorders) {
       extraBorders = {
         border: `${get(theme, "box.border", lightV2.disabledGrey)} 1px solid`,
-        borderRadius: 16,
-        padding: customBorderPadding || "32px 56px",
+        borderRadius: customBorderRadius || 16,
+        padding: customBorderPadding || 24,
         boxShadow: get(theme, "box.shadow", "none"),
         backgroundColor: get(theme, "box.backgroundColor", lightV2.white),
       };
@@ -47,7 +54,15 @@ const BoxParent = styled.div<BoxProps & React.HTMLAttributes<HTMLDivElement>>(
 
 const Box = React.forwardRef<React.HTMLAttributes<HTMLDivElement>, BoxProps>(
   (
-    { sx, children, customBorderPadding, className, withBorders, ...props },
+    {
+      sx,
+      children,
+      customBorderPadding,
+      customBorderRadius = 16,
+      className,
+      withBorders,
+      ...props
+    },
     ref,
   ) => {
     return (
@@ -55,6 +70,7 @@ const Box = React.forwardRef<React.HTMLAttributes<HTMLDivElement>, BoxProps>(
         {...props}
         sx={sx}
         customBorderPadding={customBorderPadding}
+        customBorderRadius={customBorderRadius}
         ref={ref as RefObject<HTMLDivElement> | null | undefined}
         withBorders={withBorders}
         className={`box ${withBorders ? "with-borders" : ""} ${className || ""}`}

--- a/src/components/Box/Box.types.ts
+++ b/src/components/Box/Box.types.ts
@@ -22,5 +22,6 @@ export interface BoxProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
   withBorders?: boolean;
   customBorderPadding?: number | string;
+  customBorderRadius?: number | string;
   useBackground?: boolean;
 }

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -257,9 +257,9 @@ export const lightTheme: ThemeDefinitionProps = {
   secondaryText: lightColors.mainGrey,
   colors: getThemeColors("lightMode"),
   box: {
-    border: lightV2.disabledGrey,
-    shadow: "0px 2px 8px 0px rgba(156, 163, 175, 0.15)",
-    backgroundColor: lightV2.white,
+    border: "transparent",
+    shadow: "0px 2px 2px 0px rgba(121, 135, 151, 0.15)",
+    backgroundColor: themeColors["Color/Neutral/Bg/colorBgContainer"].lightMode,
   },
   signalColors: {
     main: lightV2.switchBG,


### PR DESCRIPTION
## What does this do?

Updated Box component

- Made default padding to be `24px`
- Made default border radius to be `16px`
- Updated Box Shadow
- Added capability to edit border radius with just one prop

## How does it look?

<img width="1467" alt="Screenshot 2024-05-22 at 2 16 53 p m" src="https://github.com/minio/mds/assets/33497058/c124caf9-077d-40f8-b4d3-d626439755f9">
<img width="1474" alt="Screenshot 2024-05-22 at 2 16 35 p m" src="https://github.com/minio/mds/assets/33497058/00c36e41-d1f9-4e0a-a509-9b486f620d12">
<img width="1462" alt="Screenshot 2024-05-22 at 2 15 53 p m" src="https://github.com/minio/mds/assets/33497058/aef71966-27e8-4f05-a46d-b1ab95c41957">
