### PR TITLE
Updated Tag styles

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -40,16 +40,9 @@ const Template: Story<TagProps> = ({
   return (
     <StoryThemeProvider>
       <GlobalStyles />
-      <Tag label={label} color={color} id={id} sx={sx} square={square} />
+      <Tag label={label} color={color} id={id} sx={sx} />
       &nbsp;
-      <Tag
-        label={label}
-        color={color}
-        id={id}
-        onDelete={onDelete}
-        sx={sx}
-        square={square}
-      >
+      <Tag label={label} color={color} id={id} onDelete={onDelete} sx={sx}>
         {" "}
         with on Delete
       </Tag>
@@ -60,44 +53,23 @@ const Template: Story<TagProps> = ({
         id={id}
         onDelete={onDelete}
         sx={sx}
-        variant={"outlined"}
-        square={square}
+        size={"small"}
       >
         {" "}
-        Outlined
+        Small Tag
       </Tag>
       &nbsp;
-      <Tag
-        label={label}
-        color={color}
-        id={id}
-        sx={sx}
-        icon={<PlusIcon />}
-        square={square}
-      >
+      <Tag label={label} color={color} id={id} sx={sx} icon={<PlusIcon />}>
         {" "}
         With an Icon
-      </Tag>
-      &nbsp;
-      <Tag
-        label={label}
-        color={color}
-        id={id}
-        sx={sx}
-        variant={"outlined"}
-        icon={<PlusIcon />}
-        square={square}
-      >
-        {" "}
-        Outlined With an Icon
       </Tag>
       &nbsp;
     </StoryThemeProvider>
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const Primary = Template.bind({});
+Primary.args = {
   label: "A Tag",
   id: "tag-test",
   onDelete: () => {
@@ -115,55 +87,14 @@ Secondary.args = {
   },
 };
 
-export const Alert = Template.bind({});
-Alert.args = {
+export const Destructive = Template.bind({});
+Destructive.args = {
   label: "A Tag",
   id: "tag-test",
-  color: "alert",
+  color: "destructive",
   onDelete: () => {
     alert("Clicked Delete Button!");
   },
-};
-
-export const Warn = Template.bind({});
-Warn.args = {
-  label: "A Tag",
-  id: "tag-test",
-  color: "warn",
-  onDelete: () => {
-    alert("Clicked Delete Button!");
-  },
-};
-
-export const Grey = Template.bind({});
-Grey.args = {
-  label: "A Tag",
-  id: "tag-test",
-  color: "grey",
-  onDelete: () => {
-    alert("Clicked Delete Button!");
-  },
-};
-
-export const Ok = Template.bind({});
-Ok.args = {
-  label: "A Tag",
-  id: "tag-test",
-  color: "ok",
-  onDelete: () => {
-    alert("Clicked Delete Button!");
-  },
-};
-
-export const Square = Template.bind({});
-Square.args = {
-  label: "A Tag",
-  id: "tag-test",
-  color: "default",
-  onDelete: () => {
-    alert("Clicked Delete Button!");
-  },
-  square: true,
 };
 
 export const CustomStyles = Template.bind({});

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -19,105 +19,109 @@ import styled from "styled-components";
 import get from "lodash/get";
 import { TagConstructProps, TagProps } from "./Tag.types";
 import { lightColors, lightV2 } from "../../global/themes";
-import { overridePropsParse } from "../../global/utils";
+import {
+  overridePropsParse,
+  paddingSizeVariants,
+  radioVariants,
+} from "../../global/utils";
 import XIcon from "../Icons/NewDesignIcons/XIcon";
+import { themeColors } from "../../global/themeColors";
 
-const TagBase = styled.span<TagConstructProps>(
-  ({ theme, color, variant, square, sx }) => {
-    return {
-      position: "relative",
-      margin: 0,
-      userSelect: "none",
-      appearance: "none",
-      maxWidth: "100%",
-      fontFamily: "'Geist', sans-serif",
-      fontSize: 13,
-      display: "inline-flex",
+const TagBase = styled.span<TagConstructProps>(({ theme, color, size, sx }) => {
+  return {
+    position: "relative",
+    margin: 0,
+    userSelect: "none",
+    appearance: "none",
+    maxWidth: "100%",
+    fontFamily: "'Geist', sans-serif",
+    fontSize: 12,
+    fontWeight: 600,
+    lineHeight: "16px",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: size === "small" ? 16 : 24,
+    color: get(
+      theme,
+      `tag.${color}.label`,
+      themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+    ),
+    background: get(
+      theme,
+      `tag.${color}.background`,
+      themeColors["Color/Brand/Primary/colorPrimaryBg"].lightMode,
+    ),
+    boxShadow: "0px 1px 0px 0px rgba(255, 255, 255, 0.25) inset",
+    borderRadius:
+      size === "large"
+        ? radioVariants.borderRadiusSM
+        : radioVariants.borderRadiusXS,
+    whiteSpace: "nowrap",
+    cursor: "default",
+    outline: 0,
+    textDecoration: "none",
+    padding:
+      size === "small"
+        ? `0 ${paddingSizeVariants.sizeXXS}px`
+        : `${paddingSizeVariants.sizeXXS}px ${paddingSizeVariants.sizeXS}px`,
+    verticalAlign: "middle",
+    gap: paddingSizeVariants.sizeXXS,
+    "& svg": {
+      width: 12,
+      height: 12,
+      fill: get(
+        theme,
+        `tag.${color}.label`,
+        themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+      ),
+    },
+    "& .deleteTagButton": {
+      backgroundColor: "transparent",
+      border: 0,
+      display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      height: 24,
-      color:
-        variant === "regular"
-          ? get(theme, `tag.${color}.label`, lightV2.white)
-          : get(theme, `tag.${color}.outlineColor`, lightV2.switchBG),
-      background:
-        variant === "regular"
-          ? get(theme, `tag.${color}.background`, lightColors.mainBlue)
-          : "transparent",
-      boxShadow: "0px 1px 0px 0px rgba(255, 255, 255, 0.25) inset",
-      borderRadius: square ? 3 : 16,
-      whiteSpace: "nowrap",
-      cursor: "default",
-      outline: 0,
-      textDecoration: "none",
-      border:
-        variant === "regular"
-          ? 0
-          : `${get(
-              theme,
-              `tag.${color}.outlineColor`,
-              lightColors.mainBlue,
-            )} 1px solid`,
-      padding: "0 10px",
-      verticalAlign: "middle",
-      gap: 8,
+      padding: 0,
+      cursor: "pointer",
+      opacity: 0.6,
+      "&:hover": {
+        opacity: 1,
+      },
       "& svg": {
-        width: 12,
-        height: 12,
-        fill:
-          variant === "regular"
-            ? get(theme, `tag.${color}.label`, lightColors.white)
-            : get(theme, `tag.${color}.outlineColor`, lightV2.switchBG),
+        color: get(
+          theme,
+          `tag.${color}.deleteColor`,
+          themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+        ),
+        fill: get(
+          theme,
+          `tag.${color}.deleteColor`,
+          themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+        ),
+        width: size === "small" ? 14 : 16,
+        height: size === "small" ? 14 : 16,
+        minWidth: size === "small" ? 14 : 16,
+        minHeight: size === "small" ? 14 : 16,
       },
-      "& .deleteTagButton": {
-        backgroundColor: "transparent",
-        border: 0,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: 0,
-        cursor: "pointer",
-        opacity: 0.6,
-        "&:hover": {
-          opacity: 1,
-        },
-        "& svg": {
-          fill:
-            variant === "regular"
-              ? get(theme, `tag.${color}.deleteColor`, lightColors.white)
-              : get(theme, `tag.${color}.background`, lightColors.mainBlue),
-          width: 10,
-          height: 10,
-          minWidth: 10,
-          minHeight: 10,
-        },
-      },
-      ...overridePropsParse(sx, theme),
-    };
-  },
-);
+    },
+    ...overridePropsParse(sx, theme),
+  };
+});
 
 const Tag: FC<TagProps & React.HTMLAttributes<HTMLSpanElement>> = ({
   children,
-  color = "default",
+  color = "primary",
   sx,
   onDelete,
   id,
   label,
-  variant = "regular",
+  size = "large",
   icon,
-  square = false,
   ...props
 }) => {
   return (
-    <TagBase
-      id={id}
-      color={color}
-      sx={sx}
-      variant={variant}
-      square={square}
-      {...props}
-    >
+    <TagBase id={id} color={color} sx={sx} size={size} {...props}>
       {icon}
       <span>
         {label}

--- a/src/components/Tag/Tag.types.ts
+++ b/src/components/Tag/Tag.types.ts
@@ -25,10 +25,9 @@ export interface TagMainProps {
 }
 
 export interface TagConstructProps {
-  color?: "default" | "secondary" | "warn" | "alert" | "ok" | "grey";
+  color?: "primary" | "secondary" | "destructive";
+  size?: "large" | "small";
   sx?: OverrideTheme;
-  variant?: "regular" | "outlined";
-  square?: boolean;
 }
 
 export type TagProps = TagMainProps & TagConstructProps;

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -295,18 +295,14 @@ export interface CodeEditorThemeProps {
 
 export interface TagVariantProps {
   background: string;
-  outlineColor?: string;
   label: string;
   deleteColor: string;
 }
 
 export interface TagThemeProps {
-  default: TagVariantProps;
+  primary: TagVariantProps;
   secondary: TagVariantProps;
-  warn: TagVariantProps;
-  alert: TagVariantProps;
-  ok: TagVariantProps;
-  grey: TagVariantProps;
+  destructive: TagVariantProps;
 }
 
 interface SnackBarColorElements {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -866,41 +866,22 @@ export const lightTheme: ThemeDefinitionProps = {
     codeEditorRegexp: lightColors.codeEditorRegexp,
   },
   tag: {
-    alert: {
-      background: "linear-gradient(180deg, #FF4E42 0%, #ED2315 100%)",
-      label: lightV2.white,
-      deleteColor: lightV2.white,
-      outlineColor: lightV2.danger,
-    },
-    default: {
-      background: "linear-gradient(180deg, #4182F0 0%, #2B64E5 100%)",
-      label: lightV2.white,
-      deleteColor: lightV2.white,
-      outlineColor: lightV2.switchBG,
+    primary: {
+      background: themeColors["Color/Brand/Primary/colorPrimaryBg"].lightMode,
+      label: themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+      deleteColor:
+        themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
     },
     secondary: {
-      background: "linear-gradient(180deg, #4B5563 0%, #1D2125 100%)",
-      label: lightV2.white,
-      deleteColor: lightV2.white,
-      outlineColor: lightV2.fontColor,
+      background: themeColors["Color/Brand/Neutral/colorPrimaryBg"].lightMode,
+      label: themeColors["Color/Brand/Neutral/colorPrimaryText"].lightMode,
+      deleteColor:
+        themeColors["Color/Brand/Neutral/colorPrimaryText"].lightMode,
     },
-    warn: {
-      background: "linear-gradient(180deg, #fccb62 0%, #FDBC2E 100%)",
-      label: lightV2.fontColor,
-      deleteColor: lightV2.fontColor,
-      outlineColor: lightV2.orange,
-    },
-    ok: {
-      background: "linear-gradient(180deg, #48d6d6 0%, #15CBCE 100%)",
-      label: lightV2.fontColor,
-      deleteColor: lightV2.fontColor,
-      outlineColor: lightV2.green,
-    },
-    grey: {
-      background: lightV2.modalBorderColor,
-      label: lightV2.modalTitleColor,
-      deleteColor: lightV2.modalTitleColor,
-      outlineColor: lightV2.modalTitleColor,
+    destructive: {
+      background: themeColors["Color/Brand/Error/colorPrimaryBg"].lightMode,
+      label: themeColors["Color/Brand/Error/colorPrimaryText"].lightMode,
+      deleteColor: themeColors["Color/Brand/Error/colorPrimaryText"].lightMode,
     },
   },
   snackbar: {


### PR DESCRIPTION
## What does this do?

Updated Tag styles with new requirements.

Replaced tags as follows:

default => primary
secondary => secondary
alert => destructive
grey => secondary

Removed square & outlined variants

## How does it look?
<img width="1275" alt="Screenshot 2024-07-07 at 12 38 32 a m" src="https://github.com/minio/mds/assets/33497058/ec89fc9a-6fef-44a8-915f-f9db2f8b6d96">
<img width="1328" alt="Screenshot 2024-07-07 at 12 38 27 a m" src="https://github.com/minio/mds/assets/33497058/4c89306c-51be-44de-917c-e209ae6e3bb6">
<img width="1295" alt="Screenshot 2024-07-07 at 12 38 23 a m" src="https://github.com/minio/mds/assets/33497058/2e4008ea-efd9-4d6a-880c-55a7081a5608">

