### PR TITLE
Updated border-box sizing for overlay object

### DIFF
--- a/src/components/InputBox/InputBox.tsx
+++ b/src/components/InputBox/InputBox.tsx
@@ -146,6 +146,7 @@ const InputContainer = styled.div<InputContainerProps>(
         borderLeft: `1px solid ${theme.colors["Color/Neutral/Border/colorBorderSubtle"]}`,
         boxShadow: "none",
         height: sizeMode === "small" ? 26 : 36,
+        boxSizing: "border-box",
         "& .min-icon": {
           width: 16,
           height: 16,


### PR DESCRIPTION
## What does this do?

Fixes an overflow issue in input box where overlay action is set.

## How does it look?

<img width="858" alt="Screenshot 2024-07-23 at 12 13 09 p m" src="https://github.com/user-attachments/assets/6ce9edde-0685-4ecd-9efc-02f6631d940f">
<img width="1366" alt="Screenshot 2024-07-23 at 12 09 30 p m" src="https://github.com/user-attachments/assets/6c791405-4a0b-47b2-a4b9-d8c057eaf498">
<img width="863" alt="Screenshot 2024-07-23 at 12 08 54 p m" src="https://github.com/user-attachments/assets/8987b8fa-7242-448c-9861-426d6934fbfd">
<img width="960" alt="Screenshot 2024-07-23 at 12 08 50 p m" src="https://github.com/user-attachments/assets/def5d244-46f3-44c3-96d1-1435847a738d">
