### PR TITLE
Updated Button Styles

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -77,7 +77,7 @@ const CustomButton = styled.button<
     }
 
     return {
-      borderRadius: 6,
+      borderRadius: 4,
       cursor: "pointer",
       height: compact ? 28 : 36,
       fontFamily: "'Geist', sans-serif",
@@ -101,15 +101,18 @@ const CustomButton = styled.button<
         ...buttonLabelSx,
       },
       "& .buttonIcon": {
-        display: "block",
+        display: "flex",
         height: 16,
         width: 16,
-
+        minWidth: 16,
+        minHeight: 16,
+        justifyContent: "center",
+        alignItems: "center",
         "& > svg": {
           fill: get(theme, `buttons.${variant}.enabled.text`, "#000"),
           color: get(theme, `buttons.${variant}.enabled.text`, "#000"),
-          width: 14,
-          height: 14,
+          width: 16,
+          height: 16,
         },
       },
       "&:disabled": {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -125,6 +125,7 @@ const ButtonGroupMain = styled.div<ButtonGroupProps>(({ theme, sx }) => ({
         "buttonGroup.border",
         themeColors["Color/Neutral/Border/colorBorderMinimal"].lightMode,
       ),
+      boxShadow: "none",
       "& .buttonIcon > svg": {
         color: get(
           theme,
@@ -163,6 +164,7 @@ const ButtonGroupMain = styled.div<ButtonGroupProps>(({ theme, sx }) => ({
         "buttonGroup.border",
         themeColors["Color/Neutral/Border/colorBorderMinimal"].lightMode,
       ),
+      boxShadow: "none",
       "& .buttonIcon > svg": {
         color: get(
           theme,


### PR DESCRIPTION
## What does this do?

- Changed border radius from 6px to 4px
- Removed innerShadow for ButtonGroup cases
- Fixed icon alignment in Buttons
- Fixed icon size in Buttons (14px -> 16px)

## How does it look?
<img width="1110" alt="Screenshot 2024-07-23 at 1 56 39 p m" src="https://github.com/user-attachments/assets/d73531e0-4424-4599-8440-60c2812e4165">

