### PR TITLE
Misc fixes for Inputs

### DIFF
--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -48,7 +48,7 @@ const CustomLabel = styled.label<InputLabelProps>(
         display: "flex",
         alignItems: "center",
         lineHeight: lineHeightVariant,
-        minWidth: 160,
+        minWidth: 180,
         "&.noMinWidthLabel": {
           minWidth: "initial",
         },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -39,7 +39,7 @@ const Select: FC<SelectProps> = ({
   placeholder = "",
   helpTip,
   helpTipPlacement,
-  sizeMode = "small",
+  sizeMode = "large",
   orientation = "horizontal",
   state = "normal",
   readOnly = false,


### PR DESCRIPTION
## What does this do?

- Changed input label default to be 180px
- Changed default select size to be large

## How does it look?

### BEFORE
![Screenshot 2024-08-05 at 3 07 51 p m](https://github.com/user-attachments/assets/cf03fc26-1ac9-4f42-9c2e-a93cb497cec7)


![Screenshot 2024-08-05 at 3 07 09 p m](https://github.com/user-attachments/assets/87bfc728-5039-493c-8b31-104ac553992b)

### AFTER

![Screenshot 2024-08-05 at 3 07 20 p m](https://github.com/user-attachments/assets/a51555a8-d977-4703-a413-ed99c5172e0e)
![Screenshot 2024-08-05 at 3 07 41 p m](https://github.com/user-attachments/assets/1b48217c-d92b-4811-9325-f8f3c75b3f9b)

