### PR TITLE
Adjusted max height for select boxes

### DIFF
--- a/src/components/DropdownSelector/DropdownSelector.tsx
+++ b/src/components/DropdownSelector/DropdownSelector.tsx
@@ -42,7 +42,6 @@ const DropdownBlock = styled.div<DropDownBlockProps>(
       lightV2.white,
     ),
     padding: 8,
-    maxHeight: 450,
     minWidth: useAnchorWidth ? 160 : 0,
     overflowX: "hidden",
     overflowY: "auto",
@@ -175,6 +174,18 @@ const calcElementPosition = (
 
   if (useAnchorWidth) {
     returnItem.width = bounds.width;
+  }
+
+  //max height of dropdown
+
+  let defaultMaxHeight = 450;
+  returnItem.maxHeight = defaultMaxHeight;
+
+  const calcHeight =
+    window.innerHeight - bounds.top - bounds.height - defaultMaxHeight;
+
+  if (calcHeight < 0) {
+    returnItem.maxHeight = window.innerHeight - bounds.top - bounds.height - 40;
   }
 
   return returnItem;


### PR DESCRIPTION
## What does this do?

- Max Height of 450px
- In case max height exceeds the size of the view port, then we decrease the size of the dropdown

## How does it look?

![Screenshot 2024-08-05 at 4 39 18 p m](https://github.com/user-attachments/assets/ad866d8d-2eff-41f3-8749-3d952358028e)
![Screenshot 2024-08-05 at 4 39 10 p m](https://github.com/user-attachments/assets/7af33321-1f8f-498a-a444-d89751ee4826)
