### PR TITLE
Updated close icon size in modal boxes

### DIFF
--- a/src/components/ModalBox/ModalBox.tsx
+++ b/src/components/ModalBox/ModalBox.tsx
@@ -88,8 +88,8 @@ const ModalBoxContainer = styled.div<ModalBoxContainerProps>(
         width: 28,
         height: 28,
         "& > svg": {
-          width: 12,
-          height: 12,
+          width: 18,
+          height: 18,
         },
         "&:hover": {
           color: get(theme, "modalBox.closeHoverColor", "#EAEAEA"),


### PR DESCRIPTION
## What does this do?

Updated close icon size in modal boxes

## How does it look?

## BEFORE
![Screenshot 2024-08-06 at 3 32 15 p m](https://github.com/user-attachments/assets/76aedcf3-35c2-495a-9a2e-0d4de5a1fdfb)



## AFTER
![Screenshot 2024-08-06 at 3 30 04 p m](https://github.com/user-attachments/assets/e7df4f38-ba1a-464d-bac8-6fd40b80232a)
