### PR TITLE
Added NotificationStack Component

### DIFF
--- a/src/components/Loader/Loader.utils.ts
+++ b/src/components/Loader/Loader.utils.ts
@@ -1,3 +1,19 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import { keyframes } from "styled-components";
 
 export const animation1 = keyframes`0% {

--- a/src/components/NotificationAlert/NotificationAlert.stories.tsx
+++ b/src/components/NotificationAlert/NotificationAlert.stories.tsx
@@ -29,63 +29,80 @@ export default {
   argTypes: {},
 } as Meta<typeof NotificationAlert>;
 
-const Template: Story<NotificationAlertPrp> = ({ ...props }) => {
+const Template: Story<NotificationAlertPrp> = (props: NotificationAlertPrp) => {
   return (
     <StoryThemeProvider>
       <GlobalStyles />
-      <NotificationAlert {...props} designMode={"card"} />
+      <NotificationAlert
+        title={props.title}
+        children={props.children}
+        variant={props.variant}
+      />
       <br />
-      <NotificationAlert {...props} designMode={"banner"} />
+      <NotificationAlert children={props.children} variant={props.variant} />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"card"}
+        title={props.title}
+        children={props.children}
+        variant={props.variant}
         emphasisMode={"minimal"}
       />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"banner"}
+        children={props.children}
+        variant={props.variant}
         emphasisMode={"minimal"}
       />
       <br />
-      <NotificationAlert {...props} designMode={"card"} onClose={() => {}} />
-      <br />
-      <NotificationAlert {...props} designMode={"banner"} onClose={() => {}} />
+      <NotificationAlert
+        title={props.title}
+        children={props.children}
+        variant={props.variant}
+        onClose={() => {}}
+      />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"card"}
+        children={props.children}
+        variant={props.variant}
+        onClose={() => {}}
+      />
+      <br />
+      <NotificationAlert
+        title={props.title}
+        children={props.children}
+        variant={props.variant}
         onClose={() => {}}
         action={<a>Action</a>}
       />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"banner"}
+        children={props.children}
+        variant={props.variant}
         onClose={() => {}}
         action={<a>Action</a>}
       />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"card"}
+        title={props.title}
+        children={props.children}
+        variant={props.variant}
         onClose={() => {}}
         action={<a>Action</a>}
         shadow
       />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"banner"}
+        children={props.children}
+        variant={props.variant}
         onClose={() => {}}
         action={<a>Action</a>}
         shadow
       />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"card"}
+        title={props.title}
+        children={props.children}
+        variant={props.variant}
         onClose={() => {}}
         action={<a>Action</a>}
         emphasisMode={"minimal"}
@@ -93,8 +110,8 @@ const Template: Story<NotificationAlertPrp> = ({ ...props }) => {
       />
       <br />
       <NotificationAlert
-        {...props}
-        designMode={"banner"}
+        children={props.children}
+        variant={props.variant}
         onClose={() => {}}
         action={<a>Action</a>}
         emphasisMode={"minimal"}

--- a/src/components/NotificationAlert/NotificationAlert.tsx
+++ b/src/components/NotificationAlert/NotificationAlert.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { FC, Fragment, useMemo } from "react";
+import React, { FC, Fragment, HTMLAttributes, useMemo } from "react";
 import get from "lodash/get";
 import {
   NotificationAlertConstruct,
@@ -153,18 +153,23 @@ const NotificationContainer = styled.div.attrs(() => ({
   },
 );
 
-const NotificationAlert: FC<NotificationAlertPrp> = ({
-  title,
+const NotificationAlert: FC<
+  NotificationAlertPrp & HTMLAttributes<HTMLDivElement>
+> = ({
+  title = "",
   children,
   action,
   onClose,
-  designMode = "banner",
   emphasisMode = "subtle",
   variant = "information",
   shadow = false,
   isLoading,
+  id,
   sx,
+  ...restProps
 }) => {
+  const designMode = title.trim() !== "" ? "card" : "banner";
+
   const icon = useMemo(() => {
     switch (variant) {
       case "information":
@@ -190,7 +195,9 @@ const NotificationAlert: FC<NotificationAlertPrp> = ({
       shadow={shadow}
       variant={variant}
       designMode={designMode}
+      id={id}
       sx={sx}
+      {...restProps}
     >
       {icon}
       <div className={"mainInfoContainer"}>

--- a/src/components/NotificationAlert/NotificationAlert.types.ts
+++ b/src/components/NotificationAlert/NotificationAlert.types.ts
@@ -27,7 +27,7 @@ export type NotificationVariant =
   | "danger";
 
 export interface NotificationAlertBase {
-  title: string;
+  title?: string;
   children: ReactNode;
   action?: ReactNode;
   isLoading?: boolean;
@@ -35,10 +35,10 @@ export interface NotificationAlertBase {
 }
 
 export interface NotificationAlertConstruct {
-  designMode?: AlertDesignMode;
   emphasisMode?: NotificationEmphasis;
   variant?: NotificationVariant;
   shadow?: boolean;
+  designMode?: AlertDesignMode;
   sx?: OverrideTheme;
 }
 

--- a/src/components/NotificationStack/NotificationStack.stories.tsx
+++ b/src/components/NotificationStack/NotificationStack.stories.tsx
@@ -22,6 +22,8 @@ import { NotificationStackProps } from "./NotificationStack.types";
 import StoryThemeProvider from "../../utils/StoryThemeProvider";
 import GlobalStyles from "../GlobalStyles/GlobalStyles";
 import { useNotifications } from "./hooks";
+import { NotificationStackContainer } from "./NotificationStack";
+import NotificationAlert from "../NotificationAlert/NotificationAlert";
 
 export default {
   title: "MDS/Information/NotificationStack",
@@ -30,7 +32,7 @@ export default {
 } as Meta<typeof Fragment>;
 
 const Template: Story<NotificationStackProps> = (args) => {
-  const { notifications, addNotification, removeNotification } =
+  const { notifications, addNotification, removeNotification, setHovered } =
     useNotifications();
 
   return (
@@ -40,24 +42,37 @@ const Template: Story<NotificationStackProps> = (args) => {
       <div>
         <button
           onClick={() =>
-            addNotification(`This is a new Notification ${Math.random()}`, 3000)
+            addNotification(
+              {
+                title: "test Title",
+                children: "This is a message for the notification",
+                variant: "information",
+              },
+              3,
+            )
           }
         >
           CLICK ME!
         </button>
         <h1>NOTIFICATIONS</h1>
-        {notifications.map((notificationElement) => (
-          <div key={notificationElement.id}>
-            {notificationElement.message}
-            <button
-              onClick={() => {
-                removeNotification(notificationElement.id);
-              }}
-            >
-              Remove
-            </button>
-          </div>
-        ))}
+        <div>
+          <NotificationStackContainer>
+            {notifications.map((notificationElement) => (
+              <NotificationAlert
+                key={`alert-${notificationElement.id}`}
+                id={`notification-${notificationElement.id}`}
+                children={notificationElement.notificationInfo.children}
+                title={"This is an alert"}
+                onClose={() => {
+                  removeNotification(notificationElement.id);
+                }}
+                variant={notificationElement.notificationInfo.variant}
+                onMouseEnter={() => setHovered(notificationElement.id, true)}
+                onMouseLeave={() => setHovered(notificationElement.id, false)}
+              />
+            ))}
+          </NotificationStackContainer>
+        </div>
       </div>
     </StoryThemeProvider>
   );

--- a/src/components/NotificationStack/NotificationStack.tsx
+++ b/src/components/NotificationStack/NotificationStack.tsx
@@ -1,0 +1,59 @@
+// This file is part of MinIO Design System
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { FC } from "react";
+import styled, { css } from "styled-components";
+import {
+  NotificationStackConstructProps,
+  NotificationStackContainerProps,
+} from "./NotificationStack.types";
+import { overridePropsParse, paddingSizeVariants } from "../../global/utils";
+import { notificationDrop } from "./NotificationStack.utils";
+
+export const NotificationStackContainer =
+  styled.div<NotificationStackConstructProps>(
+    ({ sx, theme }) => ({
+      boxSizing: "border-box",
+      display: "flex",
+      flexDirection: "column",
+      gap: paddingSizeVariants.sizeXS,
+
+      "& .notification-alert": {
+        animationDuration: "500ms" as const,
+        animationIterationCount: 1,
+        animationTimingFunction: "ease-in-out",
+        animationFillMode: "forwards",
+        animationDirection: "normal",
+      },
+      ...overridePropsParse(sx, theme),
+    }),
+    // Keyframes injected with css helper as required by styled-components (Please refer to https://styled-components.com/docs/basics#animations)
+    css`
+      .notification-alert {
+        animation-name: ${notificationDrop};
+      }
+    `,
+  );
+
+const NotificationStack: FC<
+  NotificationStackContainerProps & NotificationStackConstructProps
+> = ({ children, sx }) => {
+  return (
+    <NotificationStackContainer sx={sx}>{children}</NotificationStackContainer>
+  );
+};
+
+export default NotificationStack;

--- a/src/components/NotificationStack/NotificationStack.utils.ts
+++ b/src/components/NotificationStack/NotificationStack.utils.ts
@@ -14,22 +14,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from "react";
-import { NotificationAlertPrp } from "../NotificationAlert/NotificationAlert.types";
-import { OverrideTheme } from "../../global/global.types";
+import { keyframes } from "styled-components";
 
-export interface NotificationStackProps {
-  id: number;
-  hovered: boolean;
-  duration: number;
-  timeoutId: NodeJS.Timeout | string | number | undefined;
-  notificationInfo: NotificationAlertPrp;
-}
-
-export interface NotificationStackConstructProps {
-  sx?: OverrideTheme;
-}
-
-export interface NotificationStackContainerProps {
-  children: React.ReactNode[];
-}
+export const notificationDrop = keyframes`0% {
+                                              opacity: 0;
+                                              transform: translateY(-20%);
+                                          }
+                                              50% {
+                                                  opacity: 1;
+                                              }
+                                              100% {
+                                                  transform: translateY(0);
+                                              }`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,6 +23,11 @@ export {
   radioVariants,
 } from "../global/utils";
 
+/*Hooks*/
+export { useEscapeKey, useEnterKey, useArrowKeys } from "../global/hooks";
+export { useNotifications } from "./NotificationStack/hooks";
+
+/*Base Components*/
 export { default as ThemeHandler } from "./ThemeHandler/ThemeHandler";
 export { default as GlobalStyles } from "./GlobalStyles/GlobalStyles";
 
@@ -89,6 +94,7 @@ export { default as Pill } from "./Pill/Pill";
 export { default as SearchBox } from "./SearchBox/SearchBox";
 export { default as Badge } from "./Badge/Badge";
 export { default as NotificationAlert } from "./NotificationAlert/NotificationAlert";
+export { default as NotificationStack } from "./NotificationStack/NotificationStack";
 
 /*Icons*/
 export * from "./Icons/NewDesignIcons";
@@ -155,3 +161,4 @@ export * from "./Pill/Pill.types";
 export * from "./SearchBox/SearchBox.types";
 export * from "./Badge/Badge.types";
 export * from "./NotificationAlert/NotificationAlert.types";
+export * from "./NotificationStack/NotificationStack.types";


### PR DESCRIPTION
fixes https://github.com/miniohq/engineering/issues/2303

## What does this do?

- Added NotificationStack component & new hook to handle notifications
- Changed logic in NotificationAlert to set banner style notification when no title is set

## How does it look?

<img width="1102" alt="Screenshot 2024-08-19 at 10 13 13 p m" src="https://github.com/user-attachments/assets/74bbb698-5ca7-4f09-96db-8d1dccce040e">



![2024-08-19 22 13 56](https://github.com/user-attachments/assets/74d81d06-68d5-401d-8437-ce9f926091ba)
