### PR TITLE
Activated the disable option in dropdown menus for breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbButton.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbButton.tsx
@@ -192,6 +192,7 @@ const BreadcrumbButton: FC<
             id={`expandOption-${option.label}`}
             onClick={() => clickFunction(option)}
             icon={option.icon}
+            disabled={option.disabled}
           >
             {option.label}
           </ExpandMenuOption>

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -91,8 +91,13 @@ const subMenuOptions: BreadcrumbsOption[] = [
           console.log("clicked", dt);
         },
       },
-      { label: "SubLevel 2", to: "/lolbs22", icon: <TestIcon /> },
-      { label: "SubLevel 3", to: "/lolsb23" },
+      {
+        label: "SubLevel 2",
+        to: "/lolbs22",
+        icon: <TestIcon />,
+        disabled: true,
+      },
+      { label: "SubLevel 3", to: "/lolsb23", disabled: true },
       { label: "SubLevel 4", to: "/lolsb24", icon: <TestIcon /> },
       { label: "SubLevel 5", to: "/lolsb25" },
     ],

--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -33,6 +33,7 @@ export interface BreadcrumbsOption {
   onClick?: (to?: string) => void;
   icon?: ReactNode;
   subOptions?: BreadcrumbsOption[];
+  disabled?: boolean;
 }
 
 export interface BreadcrumbsContainerProps {


### PR DESCRIPTION
## What does this do?

Activated the disable option in dropdown menus for breadcrumbs

## How does it look?

<img width="711" alt="Screenshot 2024-08-19 at 10 39 49 p m" src="https://github.com/user-attachments/assets/516fb81f-43e2-4275-9403-d405968d35bf">
