### PR TITLE
Replaced ActionLink for LinkButton

### DIFF
--- a/src/components/LinkButton/LinkButton.stories.tsx
+++ b/src/components/LinkButton/LinkButton.stories.tsx
@@ -17,31 +17,36 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 
-import ActionLink from "./ActionLink";
-import { ActionLinkProps } from "./ActionLink.types";
+import LinkButton from "./LinkButton";
+import { LinkButtonProps } from "./LinkButton.types";
 
 import StoryThemeProvider from "../../utils/StoryThemeProvider";
 import GlobalStyles from "../GlobalStyles/GlobalStyles";
 import Link from "../Link/Link";
 
 export default {
-  title: "MDS/Forms/ActionLink",
-  component: ActionLink,
+  title: "MDS/Forms/LinkButton",
+  component: LinkButton,
   argTypes: {},
-} as Meta<typeof ActionLink>;
+} as Meta<typeof LinkButton>;
 
-const Template: Story<ActionLinkProps> = (args) => (
+const Template: Story<LinkButtonProps> = (args) => (
   <StoryThemeProvider>
     <GlobalStyles />
-    <span style={{ fontSize: 16 }}>
+    <span style={{ fontSize: 14 }}>
       Some Text that can be combined with an{" "}
-      <ActionLink
+      <LinkButton
         {...args}
         label={"Action Link"}
         onClick={() => alert("You clicked me!")}
       />
-      , this text can continue after it. This action link can be a{" "}
-      <Link className={"dark"}>Dark Link</Link>
+      . This is a disabled button{" "}
+      <LinkButton
+        {...args}
+        label={"Action Link"}
+        onClick={() => alert("You clicked me!")}
+        disabled
+      />
     </span>
   </StoryThemeProvider>
 );

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -17,37 +17,45 @@
 import React, { FC, Fragment } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
-import { ActionLinkProps, BaseActionLinkProps } from "./ActionLink.types";
-import { lightV2 } from "../../global/themes";
+import { LinkButtonProps, BaseLinkButtonProps } from "./LinkButton.types";
 import Loader from "../Loader/Loader";
 import { overridePropsParse } from "../../global/utils";
+import { themeColors } from "../../global/themeColors";
 
-const ActionLinkBase = styled.button.attrs(() => ({
-  className: "actionLink",
-}))<BaseActionLinkProps>(({ theme, sx }) => ({
+const LinkButtonBase = styled.button.attrs(() => ({
+  className: "LinkButton",
+}))<BaseLinkButtonProps>(({ theme, sx, variant }) => ({
   cursor: "pointer",
   display: "inline-flex",
   backgroundColor: "transparent",
   border: 0,
   padding: 0,
-  color: get(theme, "linkColor", lightV2.linkColor),
-  textDecoration: "underline",
+  color: get(
+    theme,
+    `linkButton.${variant}`,
+    themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+  ),
+  textDecoration: "none",
   fontSize: "inherit",
-  fontWeight: 700,
-  "&.dark": {
-    color: get(theme, "secondaryLinkColor", lightV2.modalCloseColor),
-  },
-  "&:hover": {
+  "&:hover:not(:disabled)": {
     textDecoration: "underline",
+  },
+  "&:disabled": {
+    cursor: "not-allowed",
+    color: get(
+      theme,
+      `linkButton.disabled`,
+      themeColors["Color/Neutral/Text/colorTextDisabled"].lightMode,
+    ),
   },
   ...overridePropsParse(sx, theme),
 }));
 
-const ActionLink: FC<
-  ActionLinkProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+const LinkButton: FC<
+  LinkButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
 > = ({ label = "", isLoading = false, sx, children, ...props }) => {
   return (
-    <ActionLinkBase {...props} sx={sx}>
+    <LinkButtonBase {...props} sx={sx}>
       {isLoading ? (
         <Loader style={{ width: 16, height: 16 }} />
       ) : (
@@ -56,8 +64,8 @@ const ActionLink: FC<
           {children}
         </Fragment>
       )}
-    </ActionLinkBase>
+    </LinkButtonBase>
   );
 };
 
-export default ActionLink;
+export default LinkButton;

--- a/src/components/LinkButton/LinkButton.types.ts
+++ b/src/components/LinkButton/LinkButton.types.ts
@@ -16,13 +16,16 @@
 
 import { OverrideTheme } from "../../global/global.types";
 
-export interface CommonActionLinkProps {
+export type LinkButtonVariant = "primary" | "neutral" | "destructive";
+
+export interface CommonLinkButtonProps {
   isLoading?: boolean;
   label?: any;
 }
 
-export interface BaseActionLinkProps {
+export interface BaseLinkButtonProps {
+  variant?: LinkButtonVariant;
   sx?: OverrideTheme;
 }
 
-export type ActionLinkProps = CommonActionLinkProps & BaseActionLinkProps;
+export type LinkButtonProps = CommonLinkButtonProps & BaseLinkButtonProps;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -69,7 +69,7 @@ export { default as ExpandOptionsButton } from "./ExpandOptionsButton/ExpandOpti
 export { default as Tabs } from "./Tabs/Tabs";
 export { default as CodeEditor } from "./CodeEditor/CodeEditor";
 export { default as Tag } from "./Tag/Tag";
-export { default as ActionLink } from "./ActionLink/ActionLink";
+export { default as LinkButton } from "./LinkButton/LinkButton";
 export { default as ValuePair } from "./ValuePair/ValuePair";
 export { default as ProgressBar } from "./ProgressBar/ProgressBar";
 export { default as FileSelector } from "./FileSelector/FileSelector";
@@ -138,7 +138,7 @@ export * from "./DataTable/DataTable.types";
 export * from "./Tabs/Tabs.types";
 export * from "./CodeEditor/CodeEditor.types";
 export * from "./Tag/Tag.types";
-export * from "./ActionLink/ActionLink.types";
+export * from "./LinkButton/LinkButton.types";
 export * from "./ValuePair/ValuePair.types";
 export * from "./ProgressBar/ProgressBar.types";
 export * from "./FileSelector/FileSelector.types";

--- a/src/global/global.types.ts
+++ b/src/global/global.types.ts
@@ -494,6 +494,13 @@ export interface NotificationAlertProps {
   danger: NotificationAlertThemeProps;
 }
 
+export interface LinkButtonThemeProps {
+  destructive: string;
+  neutral: string;
+  primary: string;
+  disabled: string;
+}
+
 export interface ThemeDefinitionProps {
   bgColor: string;
   fontColor: string;
@@ -558,6 +565,7 @@ export interface ThemeDefinitionProps {
   pill?: PillThemeProps;
   badge?: BadgeThemeProps;
   notificationAlert: NotificationAlertProps;
+  linkButton: LinkButtonThemeProps;
 }
 
 export interface SelectOption {

--- a/src/global/themes.ts
+++ b/src/global/themes.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { NotificationAlertProps, ThemeDefinitionProps } from "./global.types";
+import { ThemeDefinitionProps } from "./global.types";
 import { themeColors, themeShadows } from "./themeColors";
 import { getThemeColors, paddingSizeVariants, radioVariants } from "./utils";
 
@@ -1261,6 +1261,12 @@ export const lightTheme: ThemeDefinitionProps = {
       titleColor: themeColors["Color/Neutral/Text/colorTextHeading"].lightMode,
     },
   },
+  linkButton: {
+    primary: themeColors["Color/Brand/Primary/colorPrimaryText"].lightMode,
+    neutral: themeColors["Color/Brand/Neutral/colorPrimaryText"].lightMode,
+    destructive: themeColors["Color/Brand/Error/colorPrimaryText"].lightMode,
+    disabled: themeColors["Color/Neutral/Text/colorTextDisabled"].lightMode,
+  },
 };
 
 export const darkTheme: ThemeDefinitionProps = {
@@ -2213,5 +2219,11 @@ export const darkTheme: ThemeDefinitionProps = {
       contentColor: themeColors["Color/Neutral/Text/colorTextLabel"].darkMode,
       titleColor: themeColors["Color/Neutral/Text/colorTextHeading"].darkMode,
     },
+  },
+  linkButton: {
+    primary: themeColors["Color/Brand/Primary/colorPrimaryText"].darkMode,
+    neutral: themeColors["Color/Brand/Neutral/colorPrimaryText"].darkMode,
+    destructive: themeColors["Color/Brand/Error/colorPrimaryText"].darkMode,
+    disabled: themeColors["Color/Neutral/Text/colorTextDisabled"].darkMode,
   },
 };


### PR DESCRIPTION
# Breaking Change

## What does this do?

- Replaced ActionLink for LinkButton
- Added new variants for this Button
- Button label size controlled by parent's container to avoid size issues

## How does it look?

<img width="1078" alt="Screenshot 2024-08-23 at 1 26 53 p m" src="https://github.com/user-attachments/assets/52d85f1c-8d2f-4cf6-9aa8-6b8fa04c482f">
<img width="1114" alt="Screenshot 2024-08-23 at 1 26 49 p m" src="https://github.com/user-attachments/assets/7b981061-ed08-4b0a-a08b-f3f7e7254e99">
<img width="1116" alt="Screenshot 2024-08-23 at 1 26 45 p m" src="https://github.com/user-attachments/assets/0cf64c34-86f5-4c8c-92c5-594c1fb5200a">
