### PR TITLE
Made actions optional for ScreenTitle

### DIFF
--- a/dist/esm/types/src/components/LinkButton/LinkButton.d.ts
+++ b/dist/esm/types/src/components/LinkButton/LinkButton.d.ts
@@ -1,0 +1,6 @@
+import React, { FC } from "react";
+import { LinkButtonProps } from "./LinkButton.types";
+declare const LinkButton: FC<
+  LinkButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+>;
+export default LinkButton;

--- a/dist/esm/types/src/components/LinkButton/LinkButton.types.d.ts
+++ b/dist/esm/types/src/components/LinkButton/LinkButton.types.d.ts
@@ -1,0 +1,11 @@
+import { OverrideTheme } from "../../global/global.types";
+export type LinkButtonVariant = "primary" | "neutral" | "destructive";
+export interface CommonLinkButtonProps {
+  isLoading?: boolean;
+  label?: any;
+}
+export interface BaseLinkButtonProps {
+  variant?: LinkButtonVariant;
+  sx?: OverrideTheme;
+}
+export type LinkButtonProps = CommonLinkButtonProps & BaseLinkButtonProps;

--- a/src/components/ScreenTitle/ScreenTitle.stories.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.stories.tsx
@@ -135,6 +135,12 @@ NoSubItems.args = {
   icon: <TestIcon />,
 };
 
+export const NoActions = Template.bind({});
+NoActions.args = {
+  title: "Object Title",
+  icon: <TestIcon />,
+};
+
 export const CustomStyles = Template.bind({});
 CustomStyles.args = {
   title: "Object Title",

--- a/src/components/ScreenTitle/ScreenTitle.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.tsx
@@ -181,7 +181,7 @@ const ScreenTitle: FC<ScreenTitleProps & HTMLAttributes<HTMLDivElement>> = ({
             )}
           </Box>
         </Box>
-        <Box className={"rightItems"}>{actions}</Box>
+        {actions && <Box className={"rightItems"}>{actions}</Box>}
       </Box>
     </ScreenTitleContainer>
   );

--- a/src/components/ScreenTitle/ScreenTitle.types.ts
+++ b/src/components/ScreenTitle/ScreenTitle.types.ts
@@ -22,7 +22,7 @@ export interface ScreenTitleProps {
   icon: React.ReactNode;
   subTitle?: React.ReactNode;
   title: string;
-  actions: React.ReactNode;
+  actions?: React.ReactNode;
   titleOptions?: ScreenTitleOptions[];
   sx?: OverrideTheme;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12601,11 +12601,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
   version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
+  checksum: 10c0/10dd9881baba22763de859e8050d6cb6e2db854197495c6f1929b08d1eb2b2b00d0b5d9b0bcee8472f1c3f4a7ef6a5d7ebe0cfd703f853aa5ae465b8404bc1ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes https://github.com/miniohq/engineering/issues/2334

## What does this do?

Made actions prop optional for ScreenTitle

## How does it look?

<img width="1742" alt="Screenshot 2024-08-27 at 10 16 24 p m" src="https://github.com/user-attachments/assets/fb7dbdf5-3607-4ce3-835d-a87162ed02c5">
