### PR TITLE
DataTable custom tooltips

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -400,7 +400,9 @@ WithItemActions.args = {
       onClick: (deleteItem: RecordType) => {
         console.log("CLOUD", deleteItem.field1);
       },
-      tooltip: "Cloud",
+      tooltip: (tooltipItem: RecordType) => {
+        return `Custom - ${tooltipItem.field1}`;
+      },
     },
   ],
   records: [

--- a/src/components/DataTable/DataTable.types.ts
+++ b/src/components/DataTable/DataTable.types.ts
@@ -36,7 +36,7 @@ export const actionsTypes = [
 export type PredefinedActionTypes = (typeof actionsTypes)[number];
 
 export interface ItemActions<T> {
-  tooltip?: string;
+  tooltip?: string | ((itemValue: T) => string);
   type: PredefinedActionTypes | React.ReactNode;
   isDisabled?: boolean | ((itemValue: T) => boolean);
   showLoader?: boolean | ((itemValue: T) => boolean);

--- a/src/components/DataTable/DataTable.utils.tsx
+++ b/src/components/DataTable/DataTable.utils.tsx
@@ -235,9 +235,19 @@ export const elementActions = <T,>(
       }
     }
 
+    let tooltip = "";
+
+    if (action.tooltip) {
+      if (typeof action.tooltip === "function") {
+        tooltip = action.tooltip(valueToSend);
+      } else {
+        tooltip = action.tooltip ?? "";
+      }
+    }
+
     return (
       <TableActionButton
-        tooltip={action.tooltip}
+        tooltip={tooltip}
         type={action.type}
         onClick={action.onClick}
         valueToSend={valueToSend}


### PR DESCRIPTION
## What does this do?

Added render function capability to DataTable Action buttons to render custom tooltips

## How does it look?

<img width="2279" alt="Screenshot 2024-09-18 at 3 05 30 p m" src="https://github.com/user-attachments/assets/5d83e646-5a88-4448-a8d4-b99de27c3346">
<img width="2269" alt="Screenshot 2024-09-18 at 3 05 25 p m" src="https://github.com/user-attachments/assets/f31fdfd8-7704-4a03-a8fb-43a8461ed893">
