### PR TITLE
Set default type of Button component to "button"

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -169,6 +169,7 @@ const CustomButton = styled.button<
 const Button: FC<
   ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
 > = ({
+  type = "button",
   label,
   variant = "secondary",
   icon,
@@ -205,6 +206,7 @@ const Button: FC<
 
   return (
     <CustomButton
+      type={type}
       onClick={onClick}
       disabled={disabled || false}
       variant={variant || "secondary"}


### PR DESCRIPTION
## What does this do

By default, the HTML `<button>` element has its `type` attribute set to `"submit"`. This behavior can inadvertently trigger form submissions when the MDS `Button` component is used within forms without explicitly specifying the type.

This PR updates the `Button` component to have `type="button"` as its default value whilst allowing it to be overridden in order to achieve the desired functionality.