### PR TITLE
Set Notifications container to position fixed

### DIFF
--- a/src/components/Menu/Vertical/MenuItem.tsx
+++ b/src/components/Menu/Vertical/MenuItem.tsx
@@ -228,6 +228,7 @@ const MenuItem: FC<MenuItemProps> = ({
           <Box className={"subItemsBox"}>
             {children.map((child) => (
               <Tooltip
+                key={child.id}
                 tooltip={visibleTooltip ? child.name : ""}
                 placement={"right"}
               >

--- a/src/components/Notifications/Notifications.stories.tsx
+++ b/src/components/Notifications/Notifications.stories.tsx
@@ -6,11 +6,9 @@ import Notifications from "./Notifications";
 import { useNotification } from "./Notifications.hooks";
 import Button from "../Button/Button";
 import {
-  durations,
   NotificationDuration,
   NotificationOptions,
   NotificationPosition,
-  positions,
 } from "./Notifications.types";
 import RadioGroup from "../RadioGroup/RadioGroup";
 import Box from "../Box/Box";
@@ -19,24 +17,30 @@ import { BellIcon } from "../Icons/NewDesignIcons";
 import Select from "../Select/Select";
 import { NotificationVariant } from "../NotificationAlert/NotificationAlert.types";
 
-type DemoProps = {
+const positions = [
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+  "top-center",
+  "bottom-center",
+];
+
+const durations = [0, 3000, 5000, 10000];
+
+interface DemoProps {
   message: string;
   children?: string;
   maxNotifications: number;
-};
+}
 
 const Demo: React.FC<DemoProps> = ({ message, children }) => {
   const notification = useNotification();
 
-  const [displayPosition, setDisplayPosition] =
-    useState<NotificationPosition>("top-center");
-  const [displayVariant, setDisplayVariant] =
-    useState<NotificationVariant>("success");
-  const [displayDuration, setDisplayDuration] =
-    useState<NotificationDuration>(5000);
-  const [displayAction, setDisplayAction] = useState<
-    React.ReactNode | undefined
-  >(undefined);
+  const [position, setPosition] = useState<NotificationPosition>("top-center");
+  const [variant, setVariant] = useState<NotificationVariant>("success");
+  const [duration, setDuration] = useState<NotificationDuration>(5000);
+  const [action, setAction] = useState<React.ReactNode | undefined>(undefined);
 
   const defaultAction = (
     <Button
@@ -52,12 +56,12 @@ const Demo: React.FC<DemoProps> = ({ message, children }) => {
   const handleNotification = () => {
     const options: NotificationOptions = {
       children,
-      position: displayPosition,
-      duration: displayDuration,
-      action: displayAction,
+      position,
+      duration,
+      action,
     };
 
-    notification[displayVariant](message, options);
+    notification[variant](message, options);
   };
 
   return (
@@ -73,21 +77,19 @@ const Demo: React.FC<DemoProps> = ({ message, children }) => {
         id="position"
         name="position"
         label="Position"
-        currentValue={displayPosition}
+        currentValue={position}
         selectorOptions={positions.map((value) => ({
           value,
           label: value,
         }))}
-        onChange={(e) =>
-          setDisplayPosition(e.target.value as NotificationPosition)
-        }
+        onChange={(e) => setPosition(e.target.value as NotificationPosition)}
       />
 
       <RadioGroup
         id="variant"
         name="variant"
         label="Variant"
-        currentValue={displayVariant}
+        currentValue={variant}
         selectorOptions={[
           { value: "success", label: "Success" },
           { value: "danger", label: "Danger" },
@@ -95,9 +97,7 @@ const Demo: React.FC<DemoProps> = ({ message, children }) => {
           { value: "information", label: "Information" },
           { value: "neutral", label: "Neutral" },
         ]}
-        onChange={(e) =>
-          setDisplayVariant(e.target.value as NotificationVariant)
-        }
+        onChange={(e) => setVariant(e.target.value as NotificationVariant)}
       />
 
       <Select
@@ -107,19 +107,15 @@ const Demo: React.FC<DemoProps> = ({ message, children }) => {
           value: value.toString(),
           label: value === 0 ? "0 (No auto-dismiss)" : value.toString(),
         }))}
-        value={displayDuration.toString()}
-        onChange={(val) =>
-          setDisplayDuration(Number(val) as NotificationDuration)
-        }
+        value={duration.toString()}
+        onChange={(val) => setDuration(Number(val) as NotificationDuration)}
       />
 
       <Checkbox
         id="action"
         label="Show Action"
-        checked={!!displayAction}
-        onChange={() =>
-          setDisplayAction((prev) => (prev ? undefined : defaultAction))
-        }
+        checked={!!action}
+        onChange={() => setAction((prev) => (prev ? undefined : defaultAction))}
       />
 
       <Button

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -19,7 +19,16 @@ import styled, { css, keyframes } from "styled-components";
 
 import NotificationAlert from "../NotificationAlert/NotificationAlert";
 import NotificationManager from "./NotificationManager";
-import { Notification, positions } from "./Notifications.types";
+import { Notification } from "./Notifications.types";
+
+const positions = [
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+  "top-center",
+  "bottom-center",
+];
 
 // Define keyframes for animations
 const slideInFromTop = keyframes`

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -89,8 +89,8 @@ const AnimatedNotification = styled.div<{
         `};
 `;
 
-const NotificationContainer = styled.div<{ position: string }>`
-  position: absolute;
+const NotificationsContainer = styled.div<{ position: string }>`
+  position: fixed;
   max-height: 100%;
   overflow: hidden;
   display: flex;
@@ -168,7 +168,7 @@ const Notifications: React.FC<NotificationsProps> = ({
         }
 
         return (
-          <NotificationContainer key={position} position={position}>
+          <NotificationsContainer key={position} position={position}>
             {notifications.map((notification) => {
               const { children, shadow = true } = notification.options;
 
@@ -195,7 +195,7 @@ const Notifications: React.FC<NotificationsProps> = ({
                 </AnimatedNotification>
               );
             })}
-          </NotificationContainer>
+          </NotificationsContainer>
         );
       })}
     </>

--- a/src/components/Notifications/Notifications.types.ts
+++ b/src/components/Notifications/Notifications.types.ts
@@ -19,20 +19,15 @@ import {
   NotificationVariant,
 } from "../NotificationAlert/NotificationAlert.types";
 
-export const positions = [
-  "top-left",
-  "top-right",
-  "bottom-left",
-  "bottom-right",
-  "top-center",
-  "bottom-center",
-] as const;
+export type NotificationPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "top-center"
+  | "bottom-center";
 
-export type NotificationPosition = (typeof positions)[number];
-
-export const durations = [0, 3000, 5000, 10000] as const;
-
-export type NotificationDuration = (typeof durations)[number];
+export type NotificationDuration = 0 | 3000 | 5000 | 10000;
 
 export interface NotificationOptions
   extends Omit<

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -238,8 +238,8 @@ const RadioGroup: FC<RadioGroupProps> = ({
         {selectorOptions && (
           <Fragment>
             {selectorOptions.map((selector) => (
-              <RadioMain>
-                <RadioContainer key={`option-${id}-${selector.value}`}>
+              <RadioMain key={`option-${id}-${selector.value}`}>
+                <RadioContainer>
                   <RadioButton
                     htmlFor={`option-${id}-${selector.value}`}
                     sx={sx}

--- a/src/components/ScreenTitle/ScreenTitle.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.tsx
@@ -171,8 +171,8 @@ const ScreenTitle: FC<ScreenTitleProps & HTMLAttributes<HTMLDivElement>> = ({
             )}
             {titleOptions && (
               <Box className={"options"}>
-                {titleOptions?.map((optionItem) => (
-                  <Box className={"optionElement"}>
+                {titleOptions?.map((optionItem, index) => (
+                  <Box className={"optionElement"} key={`option-${index}`}>
                     <Box className={"title"}>{optionItem.title}</Box>
                     <Box className={"value"}>{optionItem.value}</Box>
                   </Box>

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -171,6 +171,7 @@ const GenericWizard = ({
           {wizardSteps.map((step, index) => {
             return (
               <button
+                key={`wizard-step-${index}`}
                 id={"wizard-step-" + step.label.toLowerCase().replace(" ", "-")}
                 onClick={() => pageChange(index)}
                 disabled={linearMode ? index > currentStep : false}


### PR DESCRIPTION
## What does this do

This PR updates the Notifications container to position fixed ensuring notifications always remain visible even when the user scrolls down the page. It also prevents internal constants from being exported with the package.