### PR TITLE
Allow non options values in Select

### DIFF
--- a/src/components/ApplicationLogo/ApplicationLogo.tsx
+++ b/src/components/ApplicationLogo/ApplicationLogo.tsx
@@ -18,6 +18,9 @@ import React, { FC } from "react";
 
 import ThemedLogo from "../ThemedLogo/ThemedLogo";
 import { ApplicationLogoProps } from "./ApplicationLogo.types";
+import AIStor from "./Logos/AIStor/AIStor";
+import AIStorHorizontal from "./Logos/AIStor/AIStorHorizontal";
+import AIStorTag from "./Logos/AIStor/AIStorTag";
 import Cache from "./Logos/Cache/Cache";
 import Cloud from "./Logos/Cloud/Cloud";
 import ConsoleAGPL from "./Logos/Console/ConsoleAGPL";
@@ -44,9 +47,6 @@ import Releases from "./Logos/Releases/Releases";
 import SUBNET from "./Logos/SUBNET/SUBNET";
 import SubnetOPS from "./Logos/SubnetOPS/SubnetOPS";
 import VMBroker from "./Logos/VMBroker/VMBroker";
-import AIStorTag from "./Logos/AIStor/AIStorTag";
-import AIStor from "./Logos/AIStor/AIStor";
-import AIStorHorizontal from "./Logos/AIStor/AIStorHorizontal";
 
 const ApplicationLogo: FC<ApplicationLogoProps> = ({
   applicationName,

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -135,12 +135,6 @@ Disabled.args = {
   disabled: true,
 };
 
-export const FixedLabel = Template.bind({});
-FixedLabel.args = {
-  fixedLabel: "Autocomplete an option to trigger an action",
-  disabled: false,
-};
-
 export const OptionsWithIcons = Template.bind({});
 OptionsWithIcons.args = {
   options: [

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -15,16 +15,15 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { FC, useEffect, useMemo, useRef, useState } from "react";
-import get from "lodash/get";
 import styled from "styled-components";
 
 import { overridePropsParse } from "../../global/utils";
 import DropdownSelector from "../DropdownSelector/DropdownSelector";
 import ChevronDownIcon from "../Icons/NewDesignIcons/ChevronDownIcon";
 import ChevronUpIcon from "../Icons/NewDesignIcons/ChevronUpIcon";
+import InputBox from "../InputBox/InputBox";
 import { InputContainerProps } from "../InputBox/InputBox.types";
 import { AutocompleteProps } from "./Autocomplete.types";
-import InputBox from "../InputBox/InputBox";
 
 const InputContainer = styled.div<InputContainerProps>(({ theme, sx }) => ({
   display: "flex",

--- a/src/components/DateTimeInput/DateTimeInput.tsx
+++ b/src/components/DateTimeInput/DateTimeInput.tsx
@@ -23,10 +23,10 @@ import { overridePropsParse } from "../../global/utils";
 import Box from "../Box/Box";
 import ChevronDownIcon from "../Icons/NewDesignIcons/ChevronDownIcon";
 import ChevronUpIcon from "../Icons/NewDesignIcons/ChevronUpIcon";
+import InputBox from "../InputBox/InputBox";
 import { InputContainerProps } from "../InputBox/InputBox.types";
 import { DateTimeInputProps } from "./DateTimeInput.types";
 import DateTimeSelector from "./DateTimeSelector";
-import InputBox from "../InputBox/InputBox";
 
 const InputContainer = styled.div<InputContainerProps>(({ theme, sx }) => ({
   display: "flex",

--- a/src/components/ScreenTitle/ScreenTitle.tsx
+++ b/src/components/ScreenTitle/ScreenTitle.tsx
@@ -18,7 +18,6 @@ import React, { FC, HTMLAttributes } from "react";
 import get from "lodash/get";
 import styled from "styled-components";
 
-import { themeColors } from "../../global/themeColors";
 import { lightV2 } from "../../global/themes";
 import {
   breakPoints,

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -39,7 +39,6 @@ const Template: Story<SelectProps> = ({
   required,
   tooltip,
   disabled,
-  fixedLabel = "",
   options,
   placeholder,
   sx,
@@ -76,9 +75,6 @@ const Template: Story<SelectProps> = ({
           value={selectedValue}
           onChange={(newValue, extraValue) => {
             setSelectedValue(newValue);
-            if (fixedLabel !== "") {
-              alert(`Triggered ${newValue}`);
-            }
 
             console.log(extraValue);
 
@@ -90,7 +86,6 @@ const Template: Story<SelectProps> = ({
           required={required}
           tooltip={tooltip}
           disabled={disabled}
-          fixedLabel={fixedLabel}
           placeholder={placeholder}
           sx={sx}
         />
@@ -121,12 +116,6 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   label: "A Select box",
   disabled: true,
-};
-
-export const FixedLabel = Template.bind({});
-FixedLabel.args = {
-  fixedLabel: "Select an option to trigger an action",
-  disabled: false,
 };
 
 export const OptionsWithIcons = Template.bind({});

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -53,6 +53,8 @@ const Select: FC<SelectProps> = ({
 
   const selectedLabel = options.find((option) => option.value === value);
 
+  const displayValue = selectedLabel ? selectedLabel.label : value;
+
   if (!selectedLabel && fixedLabel === "" && placeholder === "") {
     console.warn("The selected value is not included in Options List");
   }
@@ -65,7 +67,7 @@ const Select: FC<SelectProps> = ({
       required={required}
       tooltip={tooltip}
       noLabelMinWidth={noLabelMinWidth}
-      value={selectedLabel?.label}
+      value={displayValue}
       sx={{
         ...sx,
         "& .overlayAction > button": {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -35,7 +35,6 @@ const Select: FC<SelectProps> = ({
   options,
   onChange,
   disabled = false,
-  fixedLabel = "",
   name,
   placeholder = "",
   helpTip,
@@ -54,10 +53,6 @@ const Select: FC<SelectProps> = ({
   const selectedLabel = options.find((option) => option.value === value);
 
   const displayValue = selectedLabel ? selectedLabel.label : value;
-
-  if (!selectedLabel && fixedLabel === "" && placeholder === "") {
-    console.warn("The selected value is not included in Options List");
-  }
 
   return (
     <InputBox

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -28,7 +28,6 @@ export interface SelectProps {
   label?: string;
   tooltip?: string;
   noLabelMinWidth?: boolean;
-  fixedLabel?: string;
   placeholder?: string;
   onChange: (newValue: string, extraValue?: any) => void;
   sx?: OverrideTheme;


### PR DESCRIPTION
## What does this do

This PR addresses a bug in the `Select` component where the displayed value could not be reset to a value that wasn't present in the options array.