### PR TITLE
Ensure stable references in useNotification hook

### DIFF
--- a/src/components/NotificationAlert/index.tsx
+++ b/src/components/NotificationAlert/index.tsx
@@ -96,32 +96,26 @@ const Index: FC<NotificationAlertPrp & HTMLAttributes<HTMLDivElement>> = ({
     },
   });
 
-  const wrapTextStyles = useMemo(() => {
-    if (wrapText) {
-      return css({
-        "& .alertInitLine": {
-          "& .notificationTitle": {
-            "& .cardTitle": {
-              display: "-webkit-box",
-              WebkitLineClamp: 1,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            },
-          },
-          "& .content": {
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          },
+  const wrapTextStyles = css({
+    "& .alertInitLine": {
+      "& .notificationTitle": {
+        "& .cardTitle": {
+          display: "-webkit-box",
+          WebkitLineClamp: 1,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
         },
-      });
-    } else {
-      return {};
-    }
-  }, [wrapText]);
+      },
+      "& .content": {
+        display: "-webkit-box",
+        WebkitLineClamp: 2,
+        WebkitBoxOrient: "vertical",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      },
+    },
+  });
 
   const baseStyle = css({
     display: "flex",
@@ -231,8 +225,8 @@ const Index: FC<NotificationAlertPrp & HTMLAttributes<HTMLDivElement>> = ({
       css={[
         baseStyle,
         designMode === "banner" ? bannerStyle : cardStyle,
+        ...(wrapText ? [wrapTextStyles] : []),
         overrideThemes,
-        wrapTextStyles,
       ]}
       className={"notification-alert"}
       id={id}

--- a/src/components/Notifications/Notifications.hooks.ts
+++ b/src/components/Notifications/Notifications.hooks.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import NotificationManager from "./NotificationManager";
 import { NotificationOptions } from "./Notifications.types";
@@ -59,5 +59,17 @@ export const useNotification = () => {
     NotificationManager.clearNotifications();
   }, []);
 
-  return { success, danger, warning, information, neutral, clear };
+  const notification = useMemo(
+    () => ({
+      success,
+      danger,
+      warning,
+      information,
+      neutral,
+      clear,
+    }),
+    [success, danger, warning, information, neutral, clear],
+  );
+
+  return notification;
 };


### PR DESCRIPTION
## What does this do

Added `useMemo` to memoize the returned `notification` object, preventing unnecessary re-renders and avoiding infinite loops in dependent components.