### PR TITLE
Increase Notifications z-index

### DIFF
--- a/src/components/Notifications/Notifications.styles.ts
+++ b/src/components/Notifications/Notifications.styles.ts
@@ -116,7 +116,7 @@ export const notificationsContainerStyles = (position: string) => {
     flexDirection: position.startsWith("bottom") ? "column-reverse" : "column",
     padding: 16,
     gap: 8,
-    zIndex: 1000,
+    zIndex: 9999,
     pointerEvents: "none",
     ...posLocation,
   });


### PR DESCRIPTION
## What does this do

This PR increases the `z-index` of the rendered notifications to ensure they are always visible on the screen, preventing them from being hidden behind other elements. 