### PR TITLE
Remove fullWidth prop from DOM elements

### DIFF
--- a/src/components/InputBox/index.tsx
+++ b/src/components/InputBox/index.tsx
@@ -146,7 +146,6 @@ const Inputdiv = React.forwardRef<
                 sizeMode === "small" ? inputBaseSizeSmall : {},
                 startIcon ? { paddingLeft: 35 } : {},
               ]}
-              fullWidth
               type={inputdivWrapperType}
               className={`Base_Normal inputRebase ${state}State ${value && value !== "" ? "filled" : ""}`}
               value={value}

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -89,7 +89,6 @@ const TextArea: FC<TextAreaProps> = ({
         <textarea
           css={[baseStyles, { minHeight: 92 }]}
           id={id}
-          fullWidth
           className={`Base_Normal inputRebase ${state}State`}
           data-index={index}
           rows={5}


### PR DESCRIPTION
Fixes

```
Warning: React does not recognize the `fullWidth` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fullwidth` instead. If you accidentally passed it from a parent component, remove it from the DOM element. Error Component Stack
```