### PR TITLE
Fix Border Radius in Horizontal tabs

### DIFF
--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -28,6 +28,7 @@ export const horizontalTabStyles = (theme: Theme) =>
       width: "100%",
       boxShadow: "none",
       padding: 0,
+      borderRadius: 0,
       "& .optionsList": {
         position: "relative",
         flexDirection: "row",


### PR DESCRIPTION
## What does this do?

Fixed an issue with border radius on horizontal tabs

## How does it look?

### Before
<img width="1435" alt="Screenshot 2024-10-30 at 2 55 12 p m" src="https://github.com/user-attachments/assets/dba28e74-aeae-48e4-84a7-ac7276895361">

### After

<img width="1453" alt="Screenshot 2024-10-30 at 2 55 05 p m" src="https://github.com/user-attachments/assets/4e640a69-152a-4775-ac14-dea424f6f2fe">

