### PR TITLE
Fixed padding with state icon

### DIFF
--- a/src/components/InputBox/InputBox.uikit.stories.tsx
+++ b/src/components/InputBox/InputBox.uikit.stories.tsx
@@ -319,3 +319,12 @@ Default.args = {
   placeholder: "Placeholder",
   helper: "Helper Text",
 };
+
+export const LongTextInput = Template.bind({});
+LongTextInput.args = {
+  label: "Label",
+  value:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  placeholder: "Placeholder",
+  helper: "Helper Text",
+};

--- a/src/components/InputBox/index.tsx
+++ b/src/components/InputBox/index.tsx
@@ -103,6 +103,8 @@ const Inputdiv = React.forwardRef<
       state = "normal";
     }
 
+    const hasState = state !== "normal";
+
     return (
       <div
         css={[
@@ -145,6 +147,10 @@ const Inputdiv = React.forwardRef<
                 baseStyles,
                 sizeMode === "small" ? inputBaseSizeSmall : {},
                 startIcon ? { paddingLeft: 35 } : {},
+                hasState ? { paddingRight: 30 } : {},
+                hasState && (overlayObject || inputdivWrapperIcon)
+                  ? { paddingRight: 60 }
+                  : {},
               ]}
               type={inputdivWrapperType}
               className={`Base_Normal inputRebase ${state}State ${value && value !== "" ? "filled" : ""}`}


### PR DESCRIPTION
## What does this do?

Fixed an issue with input box padding when a state icon is present

## How does it look?

### Before

<img width="1343" alt="Screenshot 2024-11-01 at 5 09 37 p m" src="https://github.com/user-attachments/assets/3ed420eb-45dd-4e66-b782-4a1c8ddef2a0">

### After
<img width="1354" alt="Screenshot 2024-11-01 at 5 16 59 p m" src="https://github.com/user-attachments/assets/d059e5b9-5a16-402f-b22c-5577b035bb98">

