### PR TITLE
Don't call `getGPUTier` when animation is disabled

### DIFF
--- a/src/components/LoginWrapper/LoginWrapper.tsx
+++ b/src/components/LoginWrapper/LoginWrapper.tsx
@@ -174,12 +174,13 @@ const LoginWrapper: FC<LoginWrapperProps> = ({
 
   useEffect(() => {
     (async () => {
-      const gpuTier = await getGPUTier();
-
-      setGPUAvailable(!!gpuTier.gpu && gpuTier.tier >= 2);
+      if (backgroundAnimation) {
+        const gpuTier = await getGPUTier();
+        setGPUAvailable(!!gpuTier.gpu && gpuTier.tier >= 2);
+      }
       return;
     })();
-  }, []);
+  }, [backgroundAnimation]);
 
   return (
     <CustomLogin>


### PR DESCRIPTION
When background animation is disabled, the `getGPUTier()` function was still invoked. This results in a call to an external site and we should allow to disable it.

PS: We probably should also fix this in the current `master` release. This is just fixing the branch that is used by upstream MinIO console.