### PR TITLE
Added option to disable password reveal functionality

### DIFF
--- a/src/components/InputBox/InputBox.stories.tsx
+++ b/src/components/InputBox/InputBox.stories.tsx
@@ -91,6 +91,15 @@ PasswordInput.args = {
   type: "password",
 };
 
+export const PasswordInputRevealDisabled = Template.bind({});
+PasswordInputRevealDisabled.args = {
+  label: "An input box",
+  required: true,
+  tooltip: "Tooltip text",
+  type: "password",
+  passwordRevealEnabled: false,
+};
+
 export const WithOverlayIcon = Template.bind({});
 WithOverlayIcon.args = {
   label: "An input box",

--- a/src/components/InputBox/InputBox.styles.ts
+++ b/src/components/InputBox/InputBox.styles.ts
@@ -192,6 +192,9 @@ export const containerSizeSmall = css({
 });
 
 export const containerOverlayIcon = css({
+  "& input": {
+    paddingRight: 37,
+  },
   "& .accessoryIcon": {
     right: 37,
   },

--- a/src/components/InputBox/InputBox.types.ts
+++ b/src/components/InputBox/InputBox.types.ts
@@ -43,4 +43,5 @@ export interface InputBoxProps
   sizeMode?: InputBoxSize;
   orientation?: InputBoxOrientation;
   disableErrorUntilFocus?: boolean;
+  passwordRevealEnabled?: boolean;
 }

--- a/src/components/InputBox/index.tsx
+++ b/src/components/InputBox/index.tsx
@@ -63,6 +63,7 @@ const Inputdiv = React.forwardRef<
       onFocus,
       disableErrorUntilFocus = false,
       children,
+      passwordRevealEnabled = true,
       value,
       ...props
     },
@@ -86,7 +87,7 @@ const Inputdiv = React.forwardRef<
     let inputdivWrapperIcon = overlayIcon;
     let inputdivWrapperType = type;
 
-    if (type === "password" && !overlayIcon) {
+    if (type === "password" && passwordRevealEnabled && !overlayIcon) {
       inputdivWrapperIcon = toggleTextInput ? <EyeOffIcon /> : <EyeIcon />;
       inputdivWrapperType = toggleTextInput ? "text" : "password";
     }
@@ -110,7 +111,9 @@ const Inputdiv = React.forwardRef<
         css={[
           containerStyles,
           sizeMode === "small" ? containerSizeSmall : {},
-          overlayIcon || type === "password" ? containerOverlayIcon : {},
+          overlayIcon || (type === "password" && passwordRevealEnabled)
+            ? containerOverlayIcon
+            : {},
           css({ flexDirection: orientation === "vertical" ? "column" : "row" }),
           overrideThemes,
         ]}


### PR DESCRIPTION
## What does this do?

Added option to disable password reveal functionality

## How does it look?

<img width="1112" alt="Screenshot 2024-11-08 at 12 31 51 p m" src="https://github.com/user-attachments/assets/76e073c6-0dd5-49f8-a6af-c15b6f86ae94">
<img width="1089" alt="Screenshot 2024-11-08 at 12 31 43 p m" src="https://github.com/user-attachments/assets/5a0ada54-c484-43e8-94bd-83593a400145">
