### PR TITLE
ExpandMenu changes

### DIFF
--- a/src/components/ExpandMenu/ExpandMenu.stories.tsx
+++ b/src/components/ExpandMenu/ExpandMenu.stories.tsx
@@ -820,8 +820,10 @@ export const ListDividersWithInputOptions = Template.bind({});
 ListDividersWithInputOptions.args = {
   id: "expand-button",
   icon: <CircleUserIcon />,
-  forInputOptions: true,
-  variant: "primary-ghost",
+  menuTopSpacing: false,
+  variant: "secondary-ghost",
+  openVariant: "primary-ghost",
+  openFeedback: true,
   children: (
     <Fragment>
       <ExpandMenuDescription

--- a/src/components/ExpandMenu/ExpandMenu.types.ts
+++ b/src/components/ExpandMenu/ExpandMenu.types.ts
@@ -24,6 +24,7 @@ export interface ExpandMenuProps {
   name?: string;
   label?: string;
   variant?: ButtonVariant;
+  openVariant?: ButtonVariant;
   icon?: ReactNode;
   iconLocation?: "start" | "end";
   children?: ReactNode | string;
@@ -31,7 +32,8 @@ export interface ExpandMenuProps {
   compact?: boolean;
   dropArrow?: boolean;
   inButtonGroup?: boolean;
-  forInputOptions?: boolean;
+  menuTopSpacing?: boolean;
+  openFeedback?: boolean;
   sx?: OverrideTheme;
 }
 

--- a/src/components/ExpandMenu/index.tsx
+++ b/src/components/ExpandMenu/index.tsx
@@ -38,7 +38,9 @@ const ExpandMenu: FC<
   disabled,
   dropArrow = true,
   compact = false,
-  forInputOptions = false,
+  menuTopSpacing = false,
+  openFeedback = false,
+  openVariant,
   inButtonGroup,
 }) => {
   const [expandedMenu, setExpandedMenu] = useState<boolean>(false);
@@ -68,7 +70,7 @@ const ExpandMenu: FC<
         icon={icon}
         iconLocation={iconLocation}
         secondaryIcon={secondary}
-        variant={variant}
+        variant={openVariant && expandedMenu ? openVariant : variant}
         name={name}
         sx={sx}
         label={label}
@@ -79,7 +81,7 @@ const ExpandMenu: FC<
           setAnchorEl(e.currentTarget);
         }}
         inButtonGroup={inButtonGroup}
-        className={expandedMenu && forInputOptions ? "active" : ""}
+        className={expandedMenu && openFeedback ? "active" : ""}
       />
 
       {expandedMenu && (
@@ -90,7 +92,7 @@ const ExpandMenu: FC<
           }}
           anchorOrigin={dropMenuPosition}
           anchorEl={anchorEl}
-          forInputOptions={forInputOptions}
+          forInputOptions={!menuTopSpacing}
         >
           {children}
         </ExpandDropdown>


### PR DESCRIPTION
## What does this do?

- Renamed forInputOptions to menuTopSpacing
- Added openFeedback prop to enable or disable background color change during menu opening
- Added openVariant to handle a secondary button variant in case of needed

## How does it look?
![2024-12-05 18 30 32](https://github.com/user-attachments/assets/2599dbcb-3858-4ec2-a4be-4f3c7a7659b4)

