### PR TITLE
Added missing margin to ExpandMenuDivider

### DIFF
--- a/src/components/ExpandMenu/ExpandMenu.styles.ts
+++ b/src/components/ExpandMenu/ExpandMenu.styles.ts
@@ -80,6 +80,7 @@ export const dividerStyles = (theme: Theme) =>
     borderRight: 0,
     borderLeft: 0,
     width: "100%",
+    margin: `7px 0`,
   });
 
 export const expandMenuDescriptionStyles = (theme: Theme) =>


### PR DESCRIPTION
## What does this do?

Added missing margin to ExpandMenuDivider

## How does it look?

<img width="263" alt="Screenshot 2024-12-11 at 1 33 00 p m" src="https://github.com/user-attachments/assets/071e5b83-2df7-4e91-8667-e7247f01fc75" />
