### PR TITLE
Added extra functionality to breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -24,6 +24,10 @@ import HomeIcon from "../../icons/HomeIcon";
 import TestIcon from "../../utils/TestIcon";
 import EyeIcon from "../../icons/EyeIcon";
 import GlobalStyles from "../GlobalStyles";
+import ButtonGroup from "../ButtonGroup";
+import Button from "../Button";
+import CopyIcon from "../../icons/CopyIcon";
+import FolderPlusIcon from "../../icons/FolderPlusIcon";
 
 export default {
   title: "MDS/Layout/Breadcrumbs",
@@ -167,4 +171,22 @@ WithSubMenus.args = {
   onClickOption: (to: string) => {
     console.log(`CLICKED OPTION`, to);
   },
+};
+
+export const WithPathActions = Template.bind({});
+WithPathActions.args = {
+  options: subMenuOptions,
+  markCurrentItem: true,
+  onClickOption: (to: string) => {
+    console.log(`CLICKED OPTION`, to);
+  },
+  goBackFunction: () => {
+    alert("Go back!");
+  },
+  pathActions: (
+    <ButtonGroup>
+      <Button id={"button-1"} icon={<FolderPlusIcon />} />
+      <Button id={"button-2"} icon={<CopyIcon />} />
+    </ButtonGroup>
+  ),
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.styles.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.styles.ts
@@ -26,12 +26,12 @@ export const breadcrumbsTheme = (theme: Theme) => ({
   display: "flex",
   alignItems: "center",
   marginRight: 10,
+  gap: 8,
   "& .breadcrumbsList": {
     display: "flex",
     flexWrap: "nowrap",
     flexGrow: 1,
     textAlign: "left" as const,
-    marginLeft: 15,
     marginRight: 10,
     overflow: "hidden",
     userSelect: "none",

--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -25,6 +25,7 @@ export interface BreadcrumbsProps {
   displayLastItems?: false | number;
   onClickOption?: (to?: string) => void;
   children?: React.ReactNode;
+  pathActions?: React.ReactNode;
   markCurrentItem?: boolean;
 }
 

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -36,6 +36,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
   onClickOption,
   markCurrentItem = false,
   children,
+  pathActions,
 }) => {
   const theme = useTheme();
 
@@ -120,6 +121,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
           }}
         />
       )}
+      {pathActions && <Box>{pathActions}</Box>}
       <Box className={"breadcrumbsList"}>
         {hasCollapsedOpts ? (
           <Fragment>


### PR DESCRIPTION
## What does this do?

- Added pathActions prop
- Fixed padding between elements

## How does it look?

<img width="792" alt="Screenshot 2024-12-17 at 5 44 43 p m" src="https://github.com/user-attachments/assets/17b5f95a-aeef-4c21-9cc8-1cc161230ede" />
